### PR TITLE
Switch queries to be case insensitive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 2020-01-12
 
 - Make GET queries case insensitive for `name` where supported.
+- Fix Home link to work when you're on the Docs page
 
 ## 2020-01-11
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## 2020-01-12
+
+- Make GET queries case insensitive for `name` where supported.
+
+## 2020-01-11
+
+- 100% Test coverage between unit and integration tests
+- Overloaded routes will be removed and moved onto routes that make sense.
+- General cleanup of the code base and breakup to make testing easier.
+
 ## 2020-01-09
 
 - Add in Docker Compose

--- a/controllers/api/abilityScoreController.js
+++ b/controllers/api/abilityScoreController.js
@@ -4,7 +4,7 @@ const utility = require('./utility');
 exports.index = async (req, res, next) => {
   const search_queries = {};
   if (req.query.name !== undefined) {
-    search_queries.name = req.query.name;
+    search_queries.name = { $regex: new RegExp(req.query.name, 'i') };
   }
 
   await AbilityScore.find(search_queries)

--- a/controllers/api/abilityScoreController.js
+++ b/controllers/api/abilityScoreController.js
@@ -4,7 +4,7 @@ const utility = require('./utility');
 exports.index = async (req, res, next) => {
   const search_queries = {};
   if (req.query.name !== undefined) {
-    search_queries.name = { $regex: new RegExp(req.query.name, 'i') };
+    search_queries.name = { $regex: new RegExp(utility.escapeRegExp(req.query.name), 'i') };
   }
 
   await AbilityScore.find(search_queries)

--- a/controllers/api/classController.js
+++ b/controllers/api/classController.js
@@ -11,7 +11,7 @@ const utility = require('./utility');
 exports.index = async (req, res, next) => {
   const search_queries = {};
   if (req.query.name !== undefined) {
-    search_queries.name = { $regex: new RegExp(req.query.name, 'i') };
+    search_queries.name = { $regex: new RegExp(utility.escapeRegExp(req.query.name), 'i') };
   }
 
   await Class.find(search_queries)

--- a/controllers/api/classController.js
+++ b/controllers/api/classController.js
@@ -11,7 +11,7 @@ const utility = require('./utility');
 exports.index = async (req, res, next) => {
   const search_queries = {};
   if (req.query.name !== undefined) {
-    search_queries.name = req.query.name;
+    search_queries.name = { $regex: new RegExp(req.query.name, 'i') };
   }
 
   await Class.find(search_queries)

--- a/controllers/api/conditionController.js
+++ b/controllers/api/conditionController.js
@@ -4,7 +4,7 @@ const utility = require('./utility');
 exports.index = async (req, res, next) => {
   const search_queries = {};
   if (req.query.name !== undefined) {
-    search_queries.name = req.query.name;
+    search_queries.name = { $regex: new RegExp(req.query.name, 'i') };
   }
 
   await Condition.find(search_queries)

--- a/controllers/api/conditionController.js
+++ b/controllers/api/conditionController.js
@@ -4,7 +4,7 @@ const utility = require('./utility');
 exports.index = async (req, res, next) => {
   const search_queries = {};
   if (req.query.name !== undefined) {
-    search_queries.name = { $regex: new RegExp(req.query.name, 'i') };
+    search_queries.name = { $regex: new RegExp(utility.escapeRegExp(req.query.name), 'i') };
   }
 
   await Condition.find(search_queries)

--- a/controllers/api/damageTypeController.js
+++ b/controllers/api/damageTypeController.js
@@ -4,7 +4,7 @@ const utility = require('./utility');
 exports.index = async (req, res, next) => {
   const search_queries = {};
   if (req.query.name !== undefined) {
-    search_queries.name = req.query.name;
+    search_queries.name = { $regex: new RegExp(req.query.name, 'i') };
   }
 
   await DamageType.find(search_queries)

--- a/controllers/api/damageTypeController.js
+++ b/controllers/api/damageTypeController.js
@@ -4,7 +4,7 @@ const utility = require('./utility');
 exports.index = async (req, res, next) => {
   const search_queries = {};
   if (req.query.name !== undefined) {
-    search_queries.name = { $regex: new RegExp(req.query.name, 'i') };
+    search_queries.name = { $regex: new RegExp(utility.escapeRegExp(req.query.name), 'i') };
   }
 
   await DamageType.find(search_queries)

--- a/controllers/api/equipmentCategoryController.js
+++ b/controllers/api/equipmentCategoryController.js
@@ -4,7 +4,7 @@ const utility = require('./utility');
 exports.index = async (req, res, next) => {
   const search_queries = {};
   if (req.query.name !== undefined) {
-    search_queries.name = { $regex: new RegExp(req.query.name, 'i') };
+    search_queries.name = { $regex: new RegExp(utility.escapeRegExp(req.query.name), 'i') };
   }
 
   await EquipmentCategory.find(search_queries)

--- a/controllers/api/equipmentCategoryController.js
+++ b/controllers/api/equipmentCategoryController.js
@@ -4,7 +4,7 @@ const utility = require('./utility');
 exports.index = async (req, res, next) => {
   const search_queries = {};
   if (req.query.name !== undefined) {
-    search_queries.name = req.query.name;
+    search_queries.name = { $regex: new RegExp(req.query.name, 'i') };
   }
 
   await EquipmentCategory.find(search_queries)

--- a/controllers/api/equipmentController.js
+++ b/controllers/api/equipmentController.js
@@ -4,7 +4,7 @@ const utility = require('./utility');
 exports.index = async (req, res, next) => {
   const search_queries = {};
   if (req.query.name !== undefined) {
-    search_queries.name = { $regex: new RegExp(req.query.name, 'i') };
+    search_queries.name = { $regex: new RegExp(utility.escapeRegExp(req.query.name), 'i') };
   }
 
   await Equipment.find(search_queries)

--- a/controllers/api/equipmentController.js
+++ b/controllers/api/equipmentController.js
@@ -4,7 +4,7 @@ const utility = require('./utility');
 exports.index = async (req, res, next) => {
   const search_queries = {};
   if (req.query.name !== undefined) {
-    search_queries.name = req.query.name;
+    search_queries.name = { $regex: new RegExp(req.query.name, 'i') };
   }
 
   await Equipment.find(search_queries)

--- a/controllers/api/languageController.js
+++ b/controllers/api/languageController.js
@@ -4,7 +4,7 @@ const utility = require('./utility');
 exports.index = async (req, res, next) => {
   const search_queries = {};
   if (req.query.name !== undefined) {
-    search_queries.name = req.query.name;
+    search_queries.name = { $regex: new RegExp(req.query.name, 'i') };
   }
 
   await Language.find(search_queries)

--- a/controllers/api/languageController.js
+++ b/controllers/api/languageController.js
@@ -4,7 +4,7 @@ const utility = require('./utility');
 exports.index = async (req, res, next) => {
   const search_queries = {};
   if (req.query.name !== undefined) {
-    search_queries.name = { $regex: new RegExp(req.query.name, 'i') };
+    search_queries.name = { $regex: new RegExp(utility.escapeRegExp(req.query.name), 'i') };
   }
 
   await Language.find(search_queries)

--- a/controllers/api/magicSchoolController.js
+++ b/controllers/api/magicSchoolController.js
@@ -4,7 +4,7 @@ const utility = require('./utility');
 exports.index = async (req, res, next) => {
   const search_queries = {};
   if (req.query.name !== undefined) {
-    search_queries.name = { $regex: new RegExp(req.query.name, 'i') };
+    search_queries.name = { $regex: new RegExp(utility.escapeRegExp(req.query.name), 'i') };
   }
 
   await MagicSchool.find(search_queries)

--- a/controllers/api/magicSchoolController.js
+++ b/controllers/api/magicSchoolController.js
@@ -4,7 +4,7 @@ const utility = require('./utility');
 exports.index = async (req, res, next) => {
   const search_queries = {};
   if (req.query.name !== undefined) {
-    search_queries.name = req.query.name;
+    search_queries.name = { $regex: new RegExp(req.query.name, 'i') };
   }
 
   await MagicSchool.find(search_queries)

--- a/controllers/api/monsterController.js
+++ b/controllers/api/monsterController.js
@@ -4,7 +4,7 @@ const utility = require('./utility');
 exports.index = async (req, res, next) => {
   const search_queries = {};
   if (req.query.name !== undefined) {
-    search_queries.name = { $regex: new RegExp(req.query.name, 'i') };
+    search_queries.name = { $regex: new RegExp(utility.escapeRegExp(req.query.name), 'i') };
   }
 
   await Monster.find(search_queries)

--- a/controllers/api/monsterController.js
+++ b/controllers/api/monsterController.js
@@ -4,7 +4,7 @@ const utility = require('./utility');
 exports.index = async (req, res, next) => {
   const search_queries = {};
   if (req.query.name !== undefined) {
-    search_queries.name = req.query.name;
+    search_queries.name = { $regex: new RegExp(req.query.name, 'i') };
   }
 
   await Monster.find(search_queries)

--- a/controllers/api/proficiencyController.js
+++ b/controllers/api/proficiencyController.js
@@ -4,7 +4,7 @@ const utility = require('./utility');
 exports.index = async (req, res, next) => {
   const search_queries = {};
   if (req.query.name !== undefined) {
-    search_queries.name = { $regex: new RegExp(req.query.name, 'i') };
+    search_queries.name = { $regex: new RegExp(utility.escapeRegExp(req.query.name), 'i') };
   }
 
   await Proficiency.find(search_queries)

--- a/controllers/api/proficiencyController.js
+++ b/controllers/api/proficiencyController.js
@@ -4,7 +4,7 @@ const utility = require('./utility');
 exports.index = async (req, res, next) => {
   const search_queries = {};
   if (req.query.name !== undefined) {
-    search_queries.name = req.query.name;
+    search_queries.name = { $regex: new RegExp(req.query.name, 'i') };
   }
 
   await Proficiency.find(search_queries)

--- a/controllers/api/raceController.js
+++ b/controllers/api/raceController.js
@@ -8,7 +8,7 @@ const utility = require('./utility');
 exports.index = async (req, res, next) => {
   const search_queries = {};
   if (req.query.name !== undefined) {
-    search_queries.name = req.query.name;
+    search_queries.name = { $regex: new RegExp(req.query.name, 'i') };
   }
 
   await Race.find(search_queries)

--- a/controllers/api/raceController.js
+++ b/controllers/api/raceController.js
@@ -8,7 +8,7 @@ const utility = require('./utility');
 exports.index = async (req, res, next) => {
   const search_queries = {};
   if (req.query.name !== undefined) {
-    search_queries.name = { $regex: new RegExp(req.query.name, 'i') };
+    search_queries.name = { $regex: new RegExp(utility.escapeRegExp(req.query.name), 'i') };
   }
 
   await Race.find(search_queries)

--- a/controllers/api/skillController.js
+++ b/controllers/api/skillController.js
@@ -4,7 +4,7 @@ const utility = require('./utility');
 exports.index = async (req, res, next) => {
   const search_queries = {};
   if (req.query.name !== undefined) {
-    search_queries.name = { $regex: new RegExp(req.query.name, 'i') };
+    search_queries.name = { $regex: new RegExp(utility.escapeRegExp(req.query.name), 'i') };
   }
 
   await Skill.find(search_queries)

--- a/controllers/api/skillController.js
+++ b/controllers/api/skillController.js
@@ -4,7 +4,7 @@ const utility = require('./utility');
 exports.index = async (req, res, next) => {
   const search_queries = {};
   if (req.query.name !== undefined) {
-    search_queries.name = req.query.name;
+    search_queries.name = { $regex: new RegExp(req.query.name, 'i') };
   }
 
   await Skill.find(search_queries)

--- a/controllers/api/spellController.js
+++ b/controllers/api/spellController.js
@@ -4,7 +4,7 @@ const utility = require('./utility');
 exports.index = async (req, res, next) => {
   const search_queries = {};
   if (req.query.name !== undefined) {
-    search_queries.name = req.query.name;
+    search_queries.name = { $regex: new RegExp(req.query.name, 'i') };
   }
 
   await Spell.find(search_queries)

--- a/controllers/api/spellController.js
+++ b/controllers/api/spellController.js
@@ -4,7 +4,7 @@ const utility = require('./utility');
 exports.index = async (req, res, next) => {
   const search_queries = {};
   if (req.query.name !== undefined) {
-    search_queries.name = { $regex: new RegExp(req.query.name, 'i') };
+    search_queries.name = { $regex: new RegExp(utility.escapeRegExp(req.query.name), 'i') };
   }
 
   await Spell.find(search_queries)

--- a/controllers/api/subclassController.js
+++ b/controllers/api/subclassController.js
@@ -6,7 +6,7 @@ const utility = require('./utility');
 exports.index = async (req, res, next) => {
   const search_queries = {};
   if (req.query.name !== undefined) {
-    search_queries.name = { $regex: new RegExp(req.query.name, 'i') };
+    search_queries.name = { $regex: new RegExp(utility.escapeRegExp(req.query.name), 'i') };
   }
 
   await Subclass.find(search_queries)

--- a/controllers/api/subclassController.js
+++ b/controllers/api/subclassController.js
@@ -6,7 +6,7 @@ const utility = require('./utility');
 exports.index = async (req, res, next) => {
   const search_queries = {};
   if (req.query.name !== undefined) {
-    search_queries.name = req.query.name;
+    search_queries.name = { $regex: new RegExp(req.query.name, 'i') };
   }
 
   await Subclass.find(search_queries)

--- a/controllers/api/subraceController.js
+++ b/controllers/api/subraceController.js
@@ -6,7 +6,7 @@ const utility = require('./utility');
 exports.index = async (req, res, next) => {
   const search_queries = {};
   if (req.query.name !== undefined) {
-    search_queries.name = { $regex: new RegExp(req.query.name, 'i') };
+    search_queries.name = { $regex: new RegExp(utility.escapeRegExp(req.query.name), 'i') };
   }
 
   await Subrace.find(search_queries)

--- a/controllers/api/subraceController.js
+++ b/controllers/api/subraceController.js
@@ -6,7 +6,7 @@ const utility = require('./utility');
 exports.index = async (req, res, next) => {
   const search_queries = {};
   if (req.query.name !== undefined) {
-    search_queries.name = req.query.name;
+    search_queries.name = { $regex: new RegExp(req.query.name, 'i') };
   }
 
   await Subrace.find(search_queries)

--- a/controllers/api/traitController.js
+++ b/controllers/api/traitController.js
@@ -4,7 +4,7 @@ const utility = require('./utility');
 exports.index = async (req, res, next) => {
   const search_queries = {};
   if (req.query.name !== undefined) {
-    search_queries.name = { $regex: new RegExp(req.query.name, 'i') };
+    search_queries.name = { $regex: new RegExp(utility.escapeRegExp(req.query.name), 'i') };
   }
 
   await Trait.find(search_queries)

--- a/controllers/api/traitController.js
+++ b/controllers/api/traitController.js
@@ -4,7 +4,7 @@ const utility = require('./utility');
 exports.index = async (req, res, next) => {
   const search_queries = {};
   if (req.query.name !== undefined) {
-    search_queries.name = req.query.name;
+    search_queries.name = { $regex: new RegExp(req.query.name, 'i') };
   }
 
   await Trait.find(search_queries)

--- a/controllers/api/utility.js
+++ b/controllers/api/utility.js
@@ -28,7 +28,12 @@ const NamedAPIResource = data => {
   };
 };
 
+const escapeRegExp = string => {
+  return string.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'); // $& means the whole matched string
+};
+
 module.exports = {
   NamedAPIResource,
-  ClassAPIResource
+  ClassAPIResource,
+  escapeRegExp
 };

--- a/controllers/api/weaponPropertyController.js
+++ b/controllers/api/weaponPropertyController.js
@@ -4,7 +4,7 @@ const utility = require('./utility');
 exports.index = async (req, res, next) => {
   const search_queries = {};
   if (req.query.name !== undefined) {
-    search_queries.name = { $regex: new RegExp(req.query.name, 'i') };
+    search_queries.name = { $regex: new RegExp(utility.escapeRegExp(req.query.name), 'i') };
   }
 
   await WeaponProperty.find(search_queries)

--- a/controllers/api/weaponPropertyController.js
+++ b/controllers/api/weaponPropertyController.js
@@ -4,7 +4,7 @@ const utility = require('./utility');
 exports.index = async (req, res, next) => {
   const search_queries = {};
   if (req.query.name !== undefined) {
-    search_queries.name = req.query.name;
+    search_queries.name = { $regex: new RegExp(req.query.name, 'i') };
   }
 
   await WeaponProperty.find(search_queries)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1045,6 +1045,14 @@
         "ansi-styles": "^3.2.1",
         "escape-string-regexp": "^1.0.5",
         "supports-color": "^5.3.0"
+      },
+      "dependencies": {
+        "escape-string-regexp": {
+          "version": "1.0.5",
+          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+          "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+          "dev": true
+        }
       }
     },
     "chardet": {
@@ -1534,10 +1542,9 @@
       "integrity": "sha1-Aljq5NPQwJdN4cFpGI7wBR0dGYg="
     },
     "escape-string-regexp": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
-      "dev": true
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-2.0.0.tgz",
+      "integrity": "sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w=="
     },
     "escodegen": {
       "version": "1.12.1",
@@ -2009,6 +2016,14 @@
       "dev": true,
       "requires": {
         "escape-string-regexp": "^1.0.5"
+      },
+      "dependencies": {
+        "escape-string-regexp": {
+          "version": "1.0.5",
+          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+          "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+          "dev": true
+        }
       }
     },
     "file-entry-cache": {

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "cors": "^2.8.3",
     "debug": "^4.1.1",
     "ejs": "^2.5.5",
+    "escape-string-regexp": "^2.0.0",
     "eslint-plugin-jest": "^23.3.0",
     "express": "^4.17.1",
     "lodash": "^4.17.3",

--- a/tests/integration/server.itest.js
+++ b/tests/integration/server.itest.js
@@ -54,6 +54,15 @@ describe('/api/ability-scores', () => {
       expect(res.statusCode).toEqual(200);
       expect(res.body.results[0].name).toEqual(name);
     });
+
+    it('is case insensitive', async () => {
+      const indexRes = await request(app).get('/api/ability-scores');
+      const name = indexRes.body.results[1].name;
+      const queryName = name.toLowerCase();
+      const res = await request(app).get(`/api/ability-scores?name=${queryName}`);
+      expect(res.statusCode).toEqual(200);
+      expect(res.body.results[0].name).toEqual(name);
+    });
   });
   describe('/api/ability-scores/:index', () => {
     it('should return one object', async () => {
@@ -84,6 +93,15 @@ describe('/api/classes', () => {
       const indexRes = await request(app).get('/api/classes');
       const name = indexRes.body.results[1].name;
       const res = await request(app).get(`/api/classes?name=${name}`);
+      expect(res.statusCode).toEqual(200);
+      expect(res.body.results[0].name).toEqual(name);
+    });
+
+    it('is case insensitive', async () => {
+      const indexRes = await request(app).get('/api/classes');
+      const name = indexRes.body.results[1].name;
+      const queryName = name.toLowerCase();
+      const res = await request(app).get(`/api/classes?name=${queryName}`);
       expect(res.statusCode).toEqual(200);
       expect(res.body.results[0].name).toEqual(name);
     });
@@ -209,6 +227,15 @@ describe('/api/conditions', () => {
       expect(res.statusCode).toEqual(200);
       expect(res.body.results[0].name).toEqual(name);
     });
+
+    it('is case insensitive', async () => {
+      const indexRes = await request(app).get('/api/conditions');
+      const name = indexRes.body.results[1].name;
+      const queryName = name.toLowerCase();
+      const res = await request(app).get(`/api/conditions?name=${queryName}`);
+      expect(res.statusCode).toEqual(200);
+      expect(res.body.results[0].name).toEqual(name);
+    });
   });
   describe('/api/conditions/:index', () => {
     it('should return one object', async () => {
@@ -239,6 +266,15 @@ describe('/api/damage-types', () => {
       const indexRes = await request(app).get('/api/damage-types');
       const name = indexRes.body.results[1].name;
       const res = await request(app).get(`/api/damage-types?name=${name}`);
+      expect(res.statusCode).toEqual(200);
+      expect(res.body.results[0].name).toEqual(name);
+    });
+
+    it('is case insensitive', async () => {
+      const indexRes = await request(app).get('/api/damage-types');
+      const name = indexRes.body.results[1].name;
+      const queryName = name.toLowerCase();
+      const res = await request(app).get(`/api/damage-types?name=${queryName}`);
       expect(res.statusCode).toEqual(200);
       expect(res.body.results[0].name).toEqual(name);
     });
@@ -275,6 +311,15 @@ describe('/api/equipment-categories', () => {
       expect(res.statusCode).toEqual(200);
       expect(res.body.results[0].name).toEqual(name);
     });
+
+    it('is case insensitive', async () => {
+      const indexRes = await request(app).get('/api/equipment-categories');
+      const name = indexRes.body.results[1].name;
+      const queryName = name.toLowerCase();
+      const res = await request(app).get(`/api/equipment-categories?name=${queryName}`);
+      expect(res.statusCode).toEqual(200);
+      expect(res.body.results[0].name).toEqual(name);
+    });
   });
   describe('/api/equipment-categories/:index', () => {
     it('should return one object', async () => {
@@ -305,6 +350,15 @@ describe('/api/equipment', () => {
       const indexRes = await request(app).get('/api/equipment');
       const name = indexRes.body.results[1].name;
       const res = await request(app).get(`/api/equipment?name=${name}`);
+      expect(res.statusCode).toEqual(200);
+      expect(res.body.results[0].name).toEqual(name);
+    });
+
+    it('is case insensitive', async () => {
+      const indexRes = await request(app).get('/api/equipment');
+      const name = indexRes.body.results[1].name;
+      const queryName = name.toLowerCase();
+      const res = await request(app).get(`/api/equipment?name=${queryName}`);
       expect(res.statusCode).toEqual(200);
       expect(res.body.results[0].name).toEqual(name);
     });
@@ -365,6 +419,15 @@ describe('/api/languages', () => {
       expect(res.statusCode).toEqual(200);
       expect(res.body.results[0].name).toEqual(name);
     });
+
+    it('is case insensitive', async () => {
+      const indexRes = await request(app).get('/api/languages');
+      const name = indexRes.body.results[1].name;
+      const queryName = name.toLowerCase();
+      const res = await request(app).get(`/api/languages?name=${queryName}`);
+      expect(res.statusCode).toEqual(200);
+      expect(res.body.results[0].name).toEqual(name);
+    });
   });
   describe('/api/languages/:index', () => {
     it('should return one object', async () => {
@@ -395,6 +458,15 @@ describe('/api/magic-schools', () => {
       const indexRes = await request(app).get('/api/magic-schools');
       const name = indexRes.body.results[1].name;
       const res = await request(app).get(`/api/magic-schools?name=${name}`);
+      expect(res.statusCode).toEqual(200);
+      expect(res.body.results[0].name).toEqual(name);
+    });
+
+    it('is case insensitive', async () => {
+      const indexRes = await request(app).get('/api/magic-schools');
+      const name = indexRes.body.results[1].name;
+      const queryName = name.toLowerCase();
+      const res = await request(app).get(`/api/magic-schools?name=${queryName}`);
       expect(res.statusCode).toEqual(200);
       expect(res.body.results[0].name).toEqual(name);
     });
@@ -431,6 +503,15 @@ describe('/api/monsters', () => {
       expect(res.statusCode).toEqual(200);
       expect(res.body.results[0].name).toEqual(name);
     });
+
+    it('is case insensitive', async () => {
+      const indexRes = await request(app).get('/api/monsters');
+      const name = indexRes.body.results[1].name;
+      const queryName = name.toLowerCase();
+      const res = await request(app).get(`/api/monsters?name=${queryName}`);
+      expect(res.statusCode).toEqual(200);
+      expect(res.body.results[0].name).toEqual(name);
+    });
   });
   describe('/api/monsters/:index', () => {
     it('should return one object', async () => {
@@ -464,6 +545,15 @@ describe('/api/proficiencies', () => {
       expect(res.statusCode).toEqual(200);
       expect(res.body.results[0].name).toEqual(name);
     });
+
+    it('is case insensitive', async () => {
+      const indexRes = await request(app).get('/api/proficiencies');
+      const name = indexRes.body.results[1].name;
+      const queryName = name.toLowerCase();
+      const res = await request(app).get(`/api/proficiencies?name=${queryName}`);
+      expect(res.statusCode).toEqual(200);
+      expect(res.body.results[0].name).toEqual(name);
+    });
   });
   describe('/api/proficiencies/:index', () => {
     it('should return one object', async () => {
@@ -494,6 +584,15 @@ describe('/api/races', () => {
       const indexRes = await request(app).get('/api/races');
       const name = indexRes.body.results[1].name;
       const res = await request(app).get(`/api/races?name=${name}`);
+      expect(res.statusCode).toEqual(200);
+      expect(res.body.results[0].name).toEqual(name);
+    });
+
+    it('is case insensitive', async () => {
+      const indexRes = await request(app).get('/api/races');
+      const name = indexRes.body.results[1].name;
+      const queryName = name.toLowerCase();
+      const res = await request(app).get(`/api/races?name=${queryName}`);
       expect(res.statusCode).toEqual(200);
       expect(res.body.results[0].name).toEqual(name);
     });
@@ -558,6 +657,15 @@ describe('/api/skills', () => {
       expect(res.statusCode).toEqual(200);
       expect(res.body.results[0].name).toEqual(name);
     });
+
+    it('is case insensitive', async () => {
+      const indexRes = await request(app).get('/api/skills');
+      const name = indexRes.body.results[1].name;
+      const queryName = name.toLowerCase();
+      const res = await request(app).get(`/api/skills?name=${queryName}`);
+      expect(res.statusCode).toEqual(200);
+      expect(res.body.results[0].name).toEqual(name);
+    });
   });
   describe('/api/skills/:index', () => {
     it('should return one object', async () => {
@@ -615,6 +723,15 @@ describe('/api/spells', () => {
       expect(res.statusCode).toEqual(200);
       expect(res.body.results[0].name).toEqual(name);
     });
+
+    it('is case insensitive', async () => {
+      const indexRes = await request(app).get('/api/spells');
+      const name = indexRes.body.results[1].name;
+      const queryName = name.toLowerCase();
+      const res = await request(app).get(`/api/spells?name=${queryName}`);
+      expect(res.statusCode).toEqual(200);
+      expect(res.body.results[0].name).toEqual(name);
+    });
   });
   describe('/api/spells/:index', () => {
     it('should return one object', async () => {
@@ -669,6 +786,15 @@ describe('/api/subclasses', () => {
       const indexRes = await request(app).get('/api/subclasses');
       const name = indexRes.body.results[1].name;
       const res = await request(app).get(`/api/subclasses?name=${name}`);
+      expect(res.statusCode).toEqual(200);
+      expect(res.body.results[0].name).toEqual(name);
+    });
+
+    it('is case insensitive', async () => {
+      const indexRes = await request(app).get('/api/subclasses');
+      const name = indexRes.body.results[1].name;
+      const queryName = name.toLowerCase();
+      const res = await request(app).get(`/api/subclasses?name=${queryName}`);
       expect(res.statusCode).toEqual(200);
       expect(res.body.results[0].name).toEqual(name);
     });
@@ -732,6 +858,15 @@ describe('/api/subraces', () => {
       expect(res.statusCode).toEqual(200);
       expect(res.body.results[0].name).toEqual(name);
     });
+
+    it('is case insensitive', async () => {
+      const indexRes = await request(app).get('/api/subraces');
+      const name = indexRes.body.results[1].name;
+      const queryName = name.toLowerCase();
+      const res = await request(app).get(`/api/subraces?name=${queryName}`);
+      expect(res.statusCode).toEqual(200);
+      expect(res.body.results[0].name).toEqual(name);
+    });
   });
   describe('/api/subraces/:index', () => {
     it('should return one object', async () => {
@@ -782,6 +917,15 @@ describe('/api/traits', () => {
       expect(res.statusCode).toEqual(200);
       expect(res.body.results[0].name).toEqual(name);
     });
+
+    it('is case insensitive', async () => {
+      const indexRes = await request(app).get('/api/traits');
+      const name = indexRes.body.results[1].name;
+      const queryName = name.toLowerCase();
+      const res = await request(app).get(`/api/traits?name=${queryName}`);
+      expect(res.statusCode).toEqual(200);
+      expect(res.body.results[0].name).toEqual(name);
+    });
   });
   describe('/api/traits/:index', () => {
     it('should return one object', async () => {
@@ -812,6 +956,15 @@ describe('/api/weapon-properties', () => {
       const indexRes = await request(app).get('/api/weapon-properties');
       const name = indexRes.body.results[1].name;
       const res = await request(app).get(`/api/weapon-properties?name=${name}`);
+      expect(res.statusCode).toEqual(200);
+      expect(res.body.results[0].name).toEqual(name);
+    });
+
+    it('is case insensitive', async () => {
+      const indexRes = await request(app).get('/api/weapon-properties');
+      const name = indexRes.body.results[1].name;
+      const queryName = name.toLowerCase();
+      const res = await request(app).get(`/api/weapon-properties?name=${queryName}`);
       expect(res.statusCode).toEqual(200);
       expect(res.body.results[0].name).toEqual(name);
     });


### PR DESCRIPTION
## Overview
This addresses #13 

- [x] Set all endpoints that take a `name` query to be case insensitive.
- [x] Add integration tests for this.