### PR TITLE
Last remaining `startingequipment` references

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ You should get a response with the available endpoints for the root:
   "skills": "/api/skills",
   "spellcasting": "/api/spellcasting",
   "spells": "/api/spells",
-  "startingequipment": "/api/startingequipment",
+  "starting-equipment": "/api/starting-equipment",
   "subclasses": "/api/subclasses",
   "subraces": "/api/subraces",
   "traits": "/api/traits",

--- a/src/controllers/apiController.js
+++ b/src/controllers/apiController.js
@@ -14,7 +14,7 @@ const API_INDEX = {
   skills: '/api/skills',
   spellcasting: '/api/spellcasting',
   spells: '/api/spells',
-  startingequipment: '/api/startingequipment',
+  'starting-equipment': '/api/starting-equipment',
   subclasses: '/api/subclasses',
   subraces: '/api/subraces',
   traits: '/api/traits',

--- a/src/models/startingEquipment.js
+++ b/src/models/startingEquipment.js
@@ -10,4 +10,4 @@ var StartingEquipmentSchema = new Schema({
   url: String
 });
 
-module.exports = mongoose.model('StartingEquipment', StartingEquipmentSchema, 'starting-equipment');
+module.exports = mongoose.model('StartingEquipment', StartingEquipmentSchema, 'startingequipment');

--- a/src/models/startingEquipment.js
+++ b/src/models/startingEquipment.js
@@ -10,4 +10,4 @@ var StartingEquipmentSchema = new Schema({
   url: String
 });
 
-module.exports = mongoose.model('StartingEquipment', StartingEquipmentSchema, 'startingequipment');
+module.exports = mongoose.model('StartingEquipment', StartingEquipmentSchema, 'starting-equipment');

--- a/src/tests/controllers/api/classController.test.js
+++ b/src/tests/controllers/api/classController.test.js
@@ -267,7 +267,7 @@ describe('showStartingEquipmentForClass', () => {
   const findOneDoc = {
     index: 1,
     starting_equipment: [],
-    url: '/api/startingequipment/1'
+    url: '/api/starting-equipment/1'
   };
   const request = mockRequest({ params: { index: 'barbarian' } });
 

--- a/src/tests/controllers/api/startingEquipmentController.test.js
+++ b/src/tests/controllers/api/startingEquipmentController.test.js
@@ -14,17 +14,17 @@ describe('index', () => {
     {
       index: 1,
       class: 'Barbarian',
-      url: '/api/startingequipment/1'
+      url: '/api/starting-equipment/1'
     },
     {
       index: 2,
       class: 'Bard',
-      url: '/api/startingequipment/2'
+      url: '/api/starting-equipment/2'
     },
     {
       index: 3,
       class: 'Cleric',
-      url: '/api/startingequipment/3'
+      url: '/api/starting-equipment/3'
     }
   ];
   const request = mockRequest({ query: {} });
@@ -55,7 +55,7 @@ describe('show', () => {
   const findOneDoc = {
     index: 1,
     class: 'Barbarian',
-    url: '/api/startingequipment/1'
+    url: '/api/starting-equipment/1'
   };
 
   const showParams = { index: 1 };

--- a/src/views/partials/doc-resource-classes.ejs
+++ b/src/views/partials/doc-resource-classes.ejs
@@ -69,7 +69,7 @@
   }
   ],
   "starting_equipment": {
-    "url": "/api/startingequipment/11",
+    "url": "/api/starting-equipment/11",
     "class": "Warlock"
   },
   "class_levels": {
@@ -153,7 +153,7 @@
         An object with the possible choices of equipment for new characters of this class.
       </td>
       <td align="left">
-        <a href="#classapiresource">ClassAPIResource</a> (<a href="#startingequipment"
+        <a href="#classapiresource">ClassAPIResource</a> (<a href="#starting-equipment"
           >StartingEquipment</a
         >)
       </td>


### PR DESCRIPTION
## Overview

This fixes the last remaining references to `/api/startingequipment` and converts them to `/api/starting-equipment`.

## Here's a fun image for your troubles
![image](https://user-images.githubusercontent.com/353626/75291122-74a7e700-57d6-11ea-8db5-4f49c254baec.png)
