### PR TITLE
Query monsters by challenge rating

### DIFF
--- a/src/controllers/api/monsterController.js
+++ b/src/controllers/api/monsterController.js
@@ -6,6 +6,9 @@ exports.index = async (req, res, next) => {
   if (req.query.name !== undefined) {
     search_queries.name = { $regex: new RegExp(utility.escapeRegExp(req.query.name), 'i') };
   }
+  if (req.query.challenge_rating !== undefined) {
+    search_queries.challenge_rating = { $in: req.query.challenge_rating.split(',') };
+  }
 
   await Monster.find(search_queries)
     .sort({ index: 'asc' })

--- a/src/models/monster.js
+++ b/src/models/monster.js
@@ -4,7 +4,7 @@ var Schema = mongoose.Schema;
 var MonsterSchema = new Schema({
   index: String,
   name: String,
-  challenge_rating: [Number],
+  challenge_rating: Number,
   url: String
 });
 

--- a/src/models/monster.js
+++ b/src/models/monster.js
@@ -4,6 +4,7 @@ var Schema = mongoose.Schema;
 var MonsterSchema = new Schema({
   index: String,
   name: String,
+  challenge_rating: [Number],
   url: String
 });
 

--- a/src/tests/integration/server.itest.js
+++ b/src/tests/integration/server.itest.js
@@ -517,20 +517,38 @@ describe('/api/monsters', () => {
     it('returns objects with only one provided challenge rating', async () => {
       const res = await request(app).get('/api/monsters?challenge_rating=0.25');
       expect(res.statusCode).toEqual(200);
+
+      const indexRes = await request(app).get(`/api/monsters/${res.body.results[0].index}`);
+      expect(indexRes.statusCode).toEqual(200);
+      expect(indexRes.body.challenge_rating).toEqual(0.25);
     });
 
     it('returns objects with many provided challenge ratings', async () => {
-      const resCr1 = await request(app).get('/api/monsters?challenge_rating=1');
-      const resCr20 = await request(app).get('/api/monsters?challenge_rating=20');
+      const cr1Res = await request(app).get('/api/monsters?challenge_rating=1');
+      expect(cr1Res.statusCode).toEqual(200);
 
-      expect(resCr1.statusCode).toEqual(200);
-      expect(resCr20.statusCode).toEqual(200);
+      const cr20Res = await request(app).get('/api/monsters?challenge_rating=20');
+      expect(cr20Res.statusCode).toEqual(200);
 
-      const resBoth = await request(app).get('/api/monsters?challenge_rating=1,20');
-      expect(resBoth.statusCode).toEqual(200);
-      expect(resBoth.body.results.length).toEqual(
-        resCr1.body.results.length + resCr20.body.results.length
+      const bothRes = await request(app).get('/api/monsters?challenge_rating=1,20');
+      expect(bothRes.statusCode).toEqual(200);
+      expect(bothRes.body.count).toEqual(cr1Res.body.count + cr20Res.body.count);
+
+      const firstIndexRes = await request(app).get(
+        `/api/monsters/${bothRes.body.results[0].index}`
       );
+      expect(firstIndexRes.statusCode).toEqual(200);
+      expect(
+        firstIndexRes.body.challenge_rating == 1 || firstIndexRes.body.challenge_rating == 20
+      ).toBeTruthy();
+
+      const secondIndexRes = await request(app).get(
+        `/api/monsters/${bothRes.body.results[4].index}`
+      );
+      expect(secondIndexRes.statusCode).toEqual(200);
+      expect(
+        secondIndexRes.body.challenge_rating == 1 || secondIndexRes.body.challenge_rating == 20
+      ).toBeTruthy();
     });
   });
 

--- a/src/tests/integration/server.itest.js
+++ b/src/tests/integration/server.itest.js
@@ -513,6 +513,29 @@ describe('/api/monsters', () => {
       expect(res.body.results[0].name).toEqual(name);
     });
   });
+  describe('with challenge rating query', () => {
+    it('returns objects with only one provided challenge rating', async () => {
+      const res = await request(app).get('/api/monsters?challenge_rating=0.25');
+      expect(res.statusCode).toEqual(200);
+      expect(res.body.results[0].challenge_rating).toEqual(0.25);
+    });
+
+    it('returns objects with many provided challenge ratings', async () => {
+      const res = await request(app).get('/api/monsters?challenge_rating=1,20');
+      expect(res.statusCode).toEqual(200);
+
+      const [cr1, cr20] = res.body.results.reduce(
+        (result, element) => {
+          result[element.challenge_rating == 1 ? 0 : 1].push(element);
+          return result;
+        },
+        [[], []]
+      );
+      expect(cr1[0].challenge_rating).toEqual(1);
+      expect(cr20[0].challenge_rating).toEqual(20);
+    });
+  });
+
   describe('/api/monsters/:index', () => {
     it('should return one object', async () => {
       const indexRes = await request(app).get('/api/monsters');

--- a/src/tests/integration/server.itest.js
+++ b/src/tests/integration/server.itest.js
@@ -513,17 +513,23 @@ describe('/api/monsters', () => {
       expect(res.body.results[0].name).toEqual(name);
     });
   });
-  describe('with challenge rating query', () => {
-    it('returns objects with only one provided challenge rating', async () => {
+
+  describe('with only one provided challenge rating query', () => {
+    it('returns expected objects', async () => {
       const res = await request(app).get('/api/monsters?challenge_rating=0.25');
       expect(res.statusCode).toEqual(200);
 
-      const indexRes = await request(app).get(`/api/monsters/${res.body.results[0].index}`);
+      const randomIndex = Math.floor(Math.random() * res.body.results.length);
+      const randomResult = res.body.results[randomIndex];
+
+      const indexRes = await request(app).get(`/api/monsters/${randomResult.index}`);
       expect(indexRes.statusCode).toEqual(200);
       expect(indexRes.body.challenge_rating).toEqual(0.25);
     });
+  });
 
-    it('returns objects with many provided challenge ratings', async () => {
+  describe('with many provided challenge ratings query', () => {
+    it('returns expected objects', async () => {
       const cr1Res = await request(app).get('/api/monsters?challenge_rating=1');
       expect(cr1Res.statusCode).toEqual(200);
 
@@ -534,20 +540,13 @@ describe('/api/monsters', () => {
       expect(bothRes.statusCode).toEqual(200);
       expect(bothRes.body.count).toEqual(cr1Res.body.count + cr20Res.body.count);
 
-      const firstIndexRes = await request(app).get(
-        `/api/monsters/${bothRes.body.results[0].index}`
-      );
-      expect(firstIndexRes.statusCode).toEqual(200);
-      expect(
-        firstIndexRes.body.challenge_rating == 1 || firstIndexRes.body.challenge_rating == 20
-      ).toBeTruthy();
+      const randomIndex = Math.floor(Math.random() * bothRes.body.results.length);
+      const randomResult = bothRes.body.results[randomIndex];
 
-      const secondIndexRes = await request(app).get(
-        `/api/monsters/${bothRes.body.results[4].index}`
-      );
-      expect(secondIndexRes.statusCode).toEqual(200);
+      const indexRes = await request(app).get(`/api/monsters/${randomResult.index}`);
+      expect(indexRes.statusCode).toEqual(200);
       expect(
-        secondIndexRes.body.challenge_rating == 1 || secondIndexRes.body.challenge_rating == 20
+        indexRes.body.challenge_rating == 1 || indexRes.body.challenge_rating == 20
       ).toBeTruthy();
     });
   });

--- a/src/tests/integration/server.itest.js
+++ b/src/tests/integration/server.itest.js
@@ -517,22 +517,20 @@ describe('/api/monsters', () => {
     it('returns objects with only one provided challenge rating', async () => {
       const res = await request(app).get('/api/monsters?challenge_rating=0.25');
       expect(res.statusCode).toEqual(200);
-      expect(res.body.results[0].challenge_rating).toEqual(0.25);
     });
 
     it('returns objects with many provided challenge ratings', async () => {
-      const res = await request(app).get('/api/monsters?challenge_rating=1,20');
-      expect(res.statusCode).toEqual(200);
+      const resCr1 = await request(app).get('/api/monsters?challenge_rating=1');
+      const resCr20 = await request(app).get('/api/monsters?challenge_rating=20');
 
-      const [cr1, cr20] = res.body.results.reduce(
-        (result, element) => {
-          result[element.challenge_rating == 1 ? 0 : 1].push(element);
-          return result;
-        },
-        [[], []]
+      expect(resCr1.statusCode).toEqual(200);
+      expect(resCr20.statusCode).toEqual(200);
+
+      const resBoth = await request(app).get('/api/monsters?challenge_rating=1,20');
+      expect(resBoth.statusCode).toEqual(200);
+      expect(resBoth.body.results.length).toEqual(
+        resCr1.body.results.length + resCr20.body.results.length
       );
-      expect(cr1[0].challenge_rating).toEqual(1);
-      expect(cr20[0].challenge_rating).toEqual(20);
     });
   });
 


### PR DESCRIPTION
## What does this do?
Allows a user to query the monster list by challenge rating. Here are some examples:
`/monsters?challenge_rating=0`
`/monsters?challenge_rating=0.25,0.5`
`/monsters?challenge_rating=1,9,12`

## How was it tested?
Manually tested

## Is there a Github issue this is resolving?
This resolves issue #64.

## Here's a fun image for your troubles
![random photo - update me](https://picsum.photos/200)
