### PR TITLE
added query strings to search for spell levels, classes, and the school

### DIFF
--- a/src/controllers/api/spellController.js
+++ b/src/controllers/api/spellController.js
@@ -7,6 +7,21 @@ exports.index = async (req, res, next) => {
     search_queries.name = { $regex: new RegExp(utility.escapeRegExp(req.query.name), 'i') };
   }
 
+  if (req.query.level !== undefined) {
+    search_queries.level = +req.query.level;
+  }
+  
+  if (req.query.classes !== undefined) {
+    var classes = req.query.classes.split(",").map(
+      (c) => new RegExp(c, "i")
+    );
+    search_queries["classes.name"] = { "$in": classes }; 
+  }
+
+  if (req.query.school !== undefined) {
+    search_queries["school.name"] = { $regex: new RegExp(utility.escapeRegExp(req.query.school), 'i') };
+  }
+
   await Spell.find(search_queries)
     .sort({ index: 'asc' })
     .then(data => {


### PR DESCRIPTION
## What does this do?
you can query string search for spells based on their spell level and the classes that can use it and the school of magic it is from.

## How was it tested?
pulled down the api and executed query strings with the spells api

## Is there a Github issue this is resolving?
no it's new functionality and also intellectual curiousity

## Here's a fun image for your troubles
![random photo - update me](https://picsum.photos/200)
