### PR TITLE
Switch to string indices for Level objects

### DIFF
--- a/src/models/level.js
+++ b/src/models/level.js
@@ -2,7 +2,7 @@ var mongoose = require('mongoose');
 var Schema = mongoose.Schema;
 
 var LevelSchema = new Schema({
-  index: Number,
+  index: String,
   level: Number,
   url: String
 });

--- a/src/tests/controllers/api/classController.test.js
+++ b/src/tests/controllers/api/classController.test.js
@@ -106,17 +106,17 @@ describe('show', () => {
 describe('showLevelsForClass', () => {
   const findDoc = [
     {
-      index: 1,
+      index: "barbarian-1",
       level: 1,
       url: '/api/classes/barbarian/level/1'
     },
     {
-      index: 2,
+      index: "barbarian-2",
       level: 2,
       url: '/api/classes/barbarian/level/2'
     },
     {
-      index: 3,
+      index: "barbarian-3",
       level: 3,
       url: '/api/classes/barbarian/level/3'
     }
@@ -161,7 +161,7 @@ describe('showLevelsForClass', () => {
 
 describe('showLevelForClass', () => {
   const findOneDoc = {
-    index: 1,
+    index: "barbarian-1",
     level: 1,
     url: '/api/classes/barbarian/level/1'
   };

--- a/src/tests/controllers/api/classController.test.js
+++ b/src/tests/controllers/api/classController.test.js
@@ -106,17 +106,17 @@ describe('show', () => {
 describe('showLevelsForClass', () => {
   const findDoc = [
     {
-      index: "barbarian-1",
+      index: 'barbarian-1',
       level: 1,
       url: '/api/classes/barbarian/level/1'
     },
     {
-      index: "barbarian-2",
+      index: 'barbarian-2',
       level: 2,
       url: '/api/classes/barbarian/level/2'
     },
     {
-      index: "barbarian-3",
+      index: 'barbarian-3',
       level: 3,
       url: '/api/classes/barbarian/level/3'
     }
@@ -161,7 +161,7 @@ describe('showLevelsForClass', () => {
 
 describe('showLevelForClass', () => {
   const findOneDoc = {
-    index: "barbarian-1",
+    index: 'barbarian-1',
     level: 1,
     url: '/api/classes/barbarian/level/1'
   };

--- a/src/tests/controllers/api/subclassController.test.js
+++ b/src/tests/controllers/api/subclassController.test.js
@@ -101,19 +101,19 @@ describe('show', () => {
 describe('showLevelsForSubclass', () => {
   const findDoc = [
     {
-      index: 1,
+      index: "barbarian-1",
       level: 1,
-      url: '/api/classes/barbarian/level/1'
+      url: '/api/subclasses/barbarian/level/1'
     },
     {
-      index: 2,
+      index: "barbarian-2",
       level: 2,
-      url: '/api/classes/barbarian/level/2'
+      url: '/api/subclasses/barbarian/level/2'
     },
     {
-      index: 3,
+      index: "barbarian-3",
       level: 3,
-      url: '/api/classes/barbarian/level/3'
+      url: '/api/subclasses/barbarian/level/3'
     }
   ];
   const request = mockRequest({ params: { index: 'barbarian' } });
@@ -154,7 +154,7 @@ describe('showLevelsForSubclass', () => {
 
 describe('showLevelForSubclass', () => {
   const findOneDoc = {
-    index: 1,
+    index: "barbarian-1",
     level: 1,
     url: '/api/classes/barbarian/level/1'
   };

--- a/src/tests/controllers/api/subclassController.test.js
+++ b/src/tests/controllers/api/subclassController.test.js
@@ -101,17 +101,17 @@ describe('show', () => {
 describe('showLevelsForSubclass', () => {
   const findDoc = [
     {
-      index: "barbarian-1",
+      index: 'barbarian-1',
       level: 1,
       url: '/api/subclasses/barbarian/level/1'
     },
     {
-      index: "barbarian-2",
+      index: 'barbarian-2',
       level: 2,
       url: '/api/subclasses/barbarian/level/2'
     },
     {
-      index: "barbarian-3",
+      index: 'barbarian-3',
       level: 3,
       url: '/api/subclasses/barbarian/level/3'
     }
@@ -154,7 +154,7 @@ describe('showLevelsForSubclass', () => {
 
 describe('showLevelForSubclass', () => {
   const findOneDoc = {
-    index: "barbarian-1",
+    index: 'barbarian-1',
     level: 1,
     url: '/api/classes/barbarian/level/1'
   };


### PR DESCRIPTION
## What does this do?
Integrates changes to the database: indices for Level objects have been changed from integers to strings of the format `<(sub)class.index>-<level>`, e.g. `barbarian-1`, `berserker-3`.

**Important: [The PR that makes this modification to the database](https://github.com/bagelbits/5e-database/pull/245) MUST be merged before this one, to ensure minimal distruption.**

## How was it tested?
Tested with JEST, and in a local environment with the new data.

## Here's a fun image for your troubles
![indices are lettuces](https://www.memecreator.org/static/images/memes/4998729.jpg)
