### PR TITLE
Drop _id from any Mongo select

### DIFF
--- a/src/models/abilityScore.js
+++ b/src/models/abilityScore.js
@@ -2,6 +2,10 @@ var mongoose = require('mongoose');
 var Schema = mongoose.Schema;
 
 var AbilityScoreSchema = new Schema({
+  _id: {
+    type: String,
+    select: false
+  },
   index: String,
   name: String,
   url: String

--- a/src/models/class.js
+++ b/src/models/class.js
@@ -2,6 +2,10 @@ const mongoose = require('mongoose');
 const Schema = mongoose.Schema;
 
 const ClassSchema = new Schema({
+  _id: {
+    type: String,
+    select: false
+  },
   index: String,
   name: String,
   url: String

--- a/src/models/condition.js
+++ b/src/models/condition.js
@@ -2,6 +2,10 @@ var mongoose = require('mongoose');
 var Schema = mongoose.Schema;
 
 var ConditionSchema = new Schema({
+  _id: {
+    type: String,
+    select: false
+  },
   index: String,
   name: String,
   url: String

--- a/src/models/damageType.js
+++ b/src/models/damageType.js
@@ -2,6 +2,10 @@ var mongoose = require('mongoose');
 var Schema = mongoose.Schema;
 
 var DamageTypeSchema = new Schema({
+  _id: {
+    type: String,
+    select: false
+  },
   index: String,
   name: String,
   url: String

--- a/src/models/equipment.js
+++ b/src/models/equipment.js
@@ -2,6 +2,10 @@ var mongoose = require('mongoose');
 var Schema = mongoose.Schema;
 
 var EquipmentSchema = new Schema({
+  _id: {
+    type: String,
+    select: false
+  },
   index: String,
   name: String,
   url: String

--- a/src/models/equipmentCategory.js
+++ b/src/models/equipmentCategory.js
@@ -2,6 +2,10 @@ var mongoose = require('mongoose');
 var Schema = mongoose.Schema;
 
 var EquipmentCategorySchema = new Schema({
+  _id: {
+    type: String,
+    select: false
+  },
   index: String,
   name: String,
   url: String

--- a/src/models/feature.js
+++ b/src/models/feature.js
@@ -2,6 +2,10 @@ var mongoose = require('mongoose');
 var Schema = mongoose.Schema;
 
 var FeatureSchema = new Schema({
+  _id: {
+    type: String,
+    select: false
+  },
   index: String,
   name: String,
   class: {

--- a/src/models/language.js
+++ b/src/models/language.js
@@ -2,6 +2,10 @@ var mongoose = require('mongoose');
 var Schema = mongoose.Schema;
 
 var LanguageSchema = new Schema({
+  _id: {
+    type: String,
+    select: false
+  },
   index: String,
   name: String,
   url: String

--- a/src/models/level.js
+++ b/src/models/level.js
@@ -2,6 +2,10 @@ var mongoose = require('mongoose');
 var Schema = mongoose.Schema;
 
 var LevelSchema = new Schema({
+  _id: {
+    type: String,
+    select: false
+  },
   index: String,
   level: Number,
   url: String

--- a/src/models/magicSchool.js
+++ b/src/models/magicSchool.js
@@ -2,6 +2,10 @@ var mongoose = require('mongoose');
 var Schema = mongoose.Schema;
 
 var MagicSchoolSchema = new Schema({
+  _id: {
+    type: String,
+    select: false
+  },
   index: String,
   name: String,
   url: String

--- a/src/models/monster.js
+++ b/src/models/monster.js
@@ -2,6 +2,10 @@ var mongoose = require('mongoose');
 var Schema = mongoose.Schema;
 
 var MonsterSchema = new Schema({
+  _id: {
+    type: String,
+    select: false
+  },
   index: String,
   name: String,
   challenge_rating: Number,

--- a/src/models/proficiency.js
+++ b/src/models/proficiency.js
@@ -2,6 +2,10 @@ var mongoose = require('mongoose');
 var Schema = mongoose.Schema;
 
 var ProficiencySchema = new Schema({
+  _id: {
+    type: String,
+    select: false
+  },
   index: String,
   name: String,
   url: String

--- a/src/models/race.js
+++ b/src/models/race.js
@@ -2,6 +2,10 @@ var mongoose = require('mongoose');
 var Schema = mongoose.Schema;
 
 var RaceSchema = new Schema({
+  _id: {
+    type: String,
+    select: false
+  },
   index: String,
   name: String,
   url: String

--- a/src/models/skill.js
+++ b/src/models/skill.js
@@ -2,6 +2,10 @@ var mongoose = require('mongoose');
 var Schema = mongoose.Schema;
 
 var SkillSchema = new Schema({
+  _id: {
+    type: String,
+    select: false
+  },
   index: String,
   name: String,
   url: String

--- a/src/models/spell.js
+++ b/src/models/spell.js
@@ -2,6 +2,10 @@ var mongoose = require('mongoose');
 var Schema = mongoose.Schema;
 
 var SpellSchema = new Schema({
+  _id: {
+    type: String,
+    select: false
+  },
   index: String,
   name: String,
   url: String

--- a/src/models/spellcasting.js
+++ b/src/models/spellcasting.js
@@ -2,6 +2,10 @@ var mongoose = require('mongoose');
 var Schema = mongoose.Schema;
 
 var SpellcastingSchema = new Schema({
+  _id: {
+    type: String,
+    select: false
+  },
   index: String,
   class: {
     name: String,

--- a/src/models/startingEquipment.js
+++ b/src/models/startingEquipment.js
@@ -2,6 +2,10 @@ var mongoose = require('mongoose');
 var Schema = mongoose.Schema;
 
 var StartingEquipmentSchema = new Schema({
+  _id: {
+    type: String,
+    select: false
+  },
   index: String,
   class: {
     name: String,

--- a/src/models/subclass.js
+++ b/src/models/subclass.js
@@ -2,6 +2,10 @@ var mongoose = require('mongoose');
 var Schema = mongoose.Schema;
 
 var SubclassSchema = new Schema({
+  _id: {
+    type: String,
+    select: false
+  },
   index: String,
   name: String,
   url: String

--- a/src/models/subrace.js
+++ b/src/models/subrace.js
@@ -2,6 +2,10 @@ var mongoose = require('mongoose');
 var Schema = mongoose.Schema;
 
 var SubraceSchema = new Schema({
+  _id: {
+    type: String,
+    select: false
+  },
   index: String,
   name: String,
   url: String

--- a/src/models/trait.js
+++ b/src/models/trait.js
@@ -2,6 +2,10 @@ var mongoose = require('mongoose');
 var Schema = mongoose.Schema;
 
 var TraitSchema = new Schema({
+  _id: {
+    type: String,
+    select: false
+  },
   index: String,
   name: String,
   url: String

--- a/src/models/weaponProperty.js
+++ b/src/models/weaponProperty.js
@@ -2,6 +2,10 @@ var mongoose = require('mongoose');
 var Schema = mongoose.Schema;
 
 var WeaponPropertySchema = new Schema({
+  _id: {
+    type: String,
+    select: false
+  },
   index: String,
   name: String,
   url: String


### PR DESCRIPTION
## What does this do?
Makes sure `_id` no longer shows up in API requests. It changes on every DB deploy so is essentially useless.

## How was it tested?
Local testing

## Is there a Github issue this is resolving?
This resolves #80 

## Here's a fun image for your troubles
![image](https://user-images.githubusercontent.com/353626/91365775-cb5aa180-e7b6-11ea-9368-f041ab80551e.png)
