### PR TITLE
Caching spells endpoint

### DIFF
--- a/src/controllers/api/spellController.js
+++ b/src/controllers/api/spellController.js
@@ -1,5 +1,8 @@
+const { promisify } = require('util');
 const Spell = require('../../models/spell');
 const utility = require('./utility');
+const { redisClient } = require('../../util');
+const getAsync = promisify(redisClient.get).bind(redisClient);
 
 exports.index = async (req, res, next) => {
   const search_queries = {};
@@ -7,14 +10,25 @@ exports.index = async (req, res, next) => {
     search_queries.name = { $regex: new RegExp(utility.escapeRegExp(req.query.name), 'i') };
   }
 
-  await Spell.find(search_queries)
-    .sort({ index: 'asc' })
-    .then(data => {
-      res.status(200).json(utility.NamedAPIResource(data));
-    })
-    .catch(err => {
-      next(err);
-    });
+  const redisKey = req.originalUrl;
+  const data = await getAsync(redisKey).catch(_err => {
+    return;
+  });
+
+  if (data) {
+    res.status(200).json(JSON.parse(data));
+  } else {
+    await Spell.find(search_queries)
+      .sort({ index: 'asc' })
+      .then(data => {
+        const json_data = utility.NamedAPIResource(data);
+        redisClient.set(redisKey, JSON.stringify(json_data));
+        res.status(200).json(data);
+      })
+      .catch(err => {
+        next(err);
+      });
+  }
 };
 
 exports.show = async (req, res, next) => {

--- a/src/controllers/api/spellController.js
+++ b/src/controllers/api/spellController.js
@@ -20,10 +20,10 @@ exports.index = async (req, res, next) => {
   } else {
     await Spell.find(search_queries)
       .sort({ index: 'asc' })
-      .then(data => {
+      .then(async data => {
         const json_data = utility.NamedAPIResource(data);
         redisClient.set(redisKey, JSON.stringify(json_data));
-        res.status(200).json(data);
+        res.status(200).json(json_data);
       })
       .catch(err => {
         next(err);

--- a/src/start.js
+++ b/src/start.js
@@ -1,6 +1,8 @@
 const mongoose = require('mongoose');
+const { promisify } = require('util');
 const { mongodbUri, redisClient } = require('./util');
 const app = require('./server');
+const flushAsync = promisify(redisClient.flushall).bind(redisClient);
 
 // Connect to database and start the serverfuser
 mongoose
@@ -10,7 +12,7 @@ mongoose
   })
   .then(() => {
     console.log('Flushing Redis');
-    return redisClient.flushall();
+    return flushAsync();
   })
   .then(() => {
     const server = app.listen(process.env.PORT || 3000, () => {

--- a/src/tests/controllers/api/spellController.test.js
+++ b/src/tests/controllers/api/spellController.test.js
@@ -1,12 +1,23 @@
 const mockingoose = require('mockingoose').default;
+jest.mock('redis', () => {
+  const redis = require('redis-mock');
+  return redis;
+});
+const redis = require('redis');
 const { mockRequest, mockResponse, mockNext } = require('../../support/requestHelpers');
 const Spell = require('../../../models/spell');
 const SpellController = require('../../../controllers/api/spellController');
 
 let response;
 beforeEach(() => {
+  const client = redis.createClient();
+  client.flushall();
   mockingoose.resetAll();
   response = mockResponse();
+});
+
+afterAll(() => {
+  closeRedisClient();
 });
 
 describe('index', () => {

--- a/src/tests/controllers/api/spellController.test.js
+++ b/src/tests/controllers/api/spellController.test.js
@@ -5,6 +5,7 @@ jest.mock('redis', () => {
 });
 const redis = require('redis');
 const { mockRequest, mockResponse, mockNext } = require('../../support/requestHelpers');
+const { closeRedisClient } = require('../../../util');
 const Spell = require('../../../models/spell');
 const SpellController = require('../../../controllers/api/spellController');
 

--- a/src/tests/integration/server.itest.js
+++ b/src/tests/integration/server.itest.js
@@ -765,6 +765,17 @@ describe('/api/spells', () => {
     expect(res.statusCode).toEqual(200);
     expect(res.body.results.length).not.toEqual(0);
   });
+
+  it('should hit the cache', async () => {
+    redisClient.flushall();
+    const clientSet = jest.spyOn(redisClient, 'set');
+    let res = await request(app).get('/api/spells');
+    res = await request(app).get('/api/spells');
+    expect(res.statusCode).toEqual(200);
+    expect(res.body.results.length).not.toEqual(0);
+    expect(clientSet).toHaveBeenCalledTimes(1);
+  });
+
   describe('with name query', () => {
     it('returns the named object', async () => {
       const indexRes = await request(app).get('/api/spells');

--- a/src/tests/integration/server.itest.js
+++ b/src/tests/integration/server.itest.js
@@ -3,6 +3,10 @@ const request = require('supertest');
 const app = require('../../server');
 const { mongodbUri, redisClient, closeRedisClient } = require('../../util');
 
+afterEach(() => {
+  jest.clearAllMocks();
+});
+
 beforeAll(async () => {
   await mongoose.connect(mongodbUri, { useNewUrlParser: true, useUnifiedTopology: true });
 });


### PR DESCRIPTION
## What does this do?
This extends our caching to the `/api/spells` endpoint.

## How was it tested?
CI and local testing

## Is there a Github issue this is resolving?
No

## Here's a fun image for your troubles
![image](https://user-images.githubusercontent.com/353626/92046926-8abfd280-ed38-11ea-88da-2787949ae703.png)

