### PR TITLE
Update NamedAPIResource to APIReference in the Docs

### DIFF
--- a/src/views/partials/doc-left-col.ejs
+++ b/src/views/partials/doc-left-col.ejs
@@ -77,8 +77,7 @@
         <li class="parent">
           <a href="#common-models-section">Common Models</a>
           <ul>
-            <li><a href="#namedapiresource">NamedAPIResource</a></li>
-            <li><a href="#classapiresource">ClassAPIResource</a></li>
+            <li><a href="#apireference">APIReference</a></li>
             <li><a href="#choice">Choices</a></li>
             <li><a href="#cost">Cost</a></li>
           </ul>

--- a/src/views/partials/doc-resource-ability-scores.ejs
+++ b/src/views/partials/doc-resource-ability-scores.ejs
@@ -17,8 +17,9 @@
   ],
   "skills": [
   {
-  "url": "/api/skills/athletics",
-  "name": "Athletics",
+    "name": "Athletics",
+    "index": "athletics",
+    "url": "/api/skills/athletics"
   }
   ],
   "url": "/api/ability-scores/str",
@@ -59,7 +60,7 @@
       <td align="left">skills</td>
       <td align="left">A list of skills that uses this ability score</td>
       <td align="left">
-        list <a href="#namedapiresource">NamedAPIResource</a> (<a href="#skills">Skills</a>)
+        list <a href="#apireference">APIReference</a> (<a href="#skills">Skills</a>)
       </td>
     </tr>
     <tr>

--- a/src/views/partials/doc-resource-classes.ejs
+++ b/src/views/partials/doc-resource-classes.ejs
@@ -12,79 +12,82 @@
   "name": "Warlock",
   "hit_die": 8,
   "proficiency_choices": [
-  {
-    "choose": 2,
-    "type": "proficiencies",
-    "from": [
     {
-      "url": "/api/proficiencies/skill-arcana",
-      "name": "Skill: Arcana"
-    },
-    {
-      "url": "/api/proficiencies/skill-deception",
-      "name": "Skill: Deception"
-    },
-    {
-      "url": "/api/proficiencies/skill-history",
-      "name": "Skill: History"
-    },
-    {
-      "url": "/api/proficiencies/skill-intimidation",
-      "name": "Skill: Intimidation"
-    },
-    {
-      "url": "/api/proficiencies/skill-investigation",
-      "name": "Skill: Investigation"
-    },
-    {
-      "url": "/api/proficiencies/skill-nature",
-      "name": "Skill: Nature"
-    },
-    {
-      "url": "/api/proficiencies/skill-religion",
-      "name": "Skill: Religion"
+      "choose": 2,
+      "type": "proficiencies",
+      "from": [
+        {
+          "index": "skill-arcana",
+          "name": "Skill: Arcana",
+          "url": "/api/proficiencies/skill-arcana"
+        },
+        {
+          "index": "skill-deception",
+          "name": "Skill: Deception",
+          "url": "/api/proficiencies/skill-deception"
+        },
+        {
+          "index": "skill-history",
+          "name": "Skill: History",
+          "url": "/api/proficiencies/skill-history"
+        },
+        {
+          "index": "skill-intimidation",
+          "name": "Skill: Intimidation",
+          "url": "/api/proficiencies/skill-intimidation"
+        },
+        {
+          "index": "skill-investigation",
+          "name": "Skill: Investigation",
+          "url": "/api/proficiencies/skill-investigation"
+        },
+        {
+          "index": "skill-nature",
+          "name": "Skill: Nature",
+          "url": "/api/proficiencies/skill-nature"
+        },
+        {
+          "index": "skill-religion",
+          "name": "Skill: Religion",
+          "url": "/api/proficiencies/skill-religion"
+        }
+      ]
     }
-    ]
-  }
   ],
   "proficiencies": [
-  {
-    "name": "Light armor",
-    "url": "/api/proficiencies/light-armor"
-  },
-  {
-    "name": "Simple weapons",
-    "url": "/api/proficiencies/simple-weapons"
-  }
+    {
+      "index": "light-armor",
+      "name": "Light armor",
+      "url": "/api/proficiencies/light-armor"
+    },
+    {
+      "index": "simple-weapons",
+      "name": "Simple weapons",
+      "url": "/api/proficiencies/simple-weapons"
+    }
   ],
   "saving_throws": [
-  {
-    "name": "WIS",
-    "url": "/api/ability-scores/wis"
-  },
-  {
-    "name": "CHA",
-    "url": "/api/ability-scores/cha"
-  }
+    {
+      "index": "wis",
+      "name": "WIS",
+      "url": "/api/ability-scores/wis"
+    },
+    {
+      "index": "cha",
+      "name": "CHA",
+      "url": "/api/ability-scores/cha"
+    }
   ],
-  "starting_equipment": {
-    "url": "/api/starting-equipment/warlock",
-    "class": "Warlock"
-  },
-  "class_levels": {
-    "url": "/api/classes/warlock/levels",
-    "class": "Warlock"
-  },
+  "starting_equipment": "/api/starting-equipment/warlock",
+  "class_levels": "/api/classes/warlock/levels",
   "subclasses": [
-  {
-    "url": "/api/subclasses/fiend",
-    "name": "Fiend"
-  }
+    {
+      "index": "fiend",
+      "name": "Fiend",
+      "url": "/api/subclasses/fiend"
+    }
   ],
-  "spellcasting": {
-    "url": "/api/spellcasting/warlock",
-    "class": "Warlock"
-  },
+  "spellcasting": "/api/spellcasting/warlock",
   "url": "/api/classes/warlock"
 }</code></pre>
 
@@ -127,7 +130,7 @@
       <td align="left">proficiencies</td>
       <td align="left">Starting proficiencies all new characters of this class start with.</td>
       <td align="left">
-        list <a href="#namedapiresource">NamedAPIResource</a> (<a href="#proficiencies"
+        list <a href="#apireference">APIReference</a> (<a href="#proficiencies"
           >Proficiencies</a
         >)
       </td>
@@ -136,7 +139,7 @@
       <td align="left">saving_throws</td>
       <td align="left">Saving throws that the class is proficient in</td>
       <td align="left">
-        list <a href="#namedapiresource">NamedAPIResource</a> (<a href="#ability-scores"
+        list <a href="#apireference">APIReference</a> (<a href="#ability-scores"
           >Ability Scores</a
         >)
       </td>
@@ -147,9 +150,7 @@
         An object with the possible choices of equipment for new characters of this class.
       </td>
       <td align="left">
-        <a href="#classapiresource">ClassAPIResource</a> (<a href="#starting-equipment"
-          >StartingEquipment</a
-        >)
+        string (<a href="#starting-equipment">StartingEquipment</a>)
       </td>
     </tr>
     <tr>
@@ -157,13 +158,13 @@
       <td align="left">
         All possible levels that this class can obtain (excluding subclass-specific features)
       </td>
-      <td align="left">list <a href="#levels">Levels</a></td>
+      <td align="left">string (<a href="#levels">Levels</a>)</td>
     </tr>
     <tr>
       <td align="left">subclasses</td>
       <td align="left">All possible subclasses that this class can specialize in.</td>
       <td align="left">
-        list <a href="#namedapiresource">NamedAPIResource</a> (<a href="#subclass">Subclass</a>)
+        list <a href="#apireference">APIReference</a> (<a href="#subclass">Subclass</a>)
       </td>
     </tr>
     <tr>
@@ -173,7 +174,7 @@
         known, spellcasting ability, and cantrips known.
       </td>
       <td align="left">
-        <a href="#classapiresource">ClassAPIResource</a> (<a href="#spellcasting">Spellcasting</a>)
+        string (<a href="#spellcasting">Spellcasting</a>)
       </td>
     </tr>
     <tr>
@@ -190,12 +191,12 @@
   "count": 1,
   "results": [
     {
-    "index": "lore",
-    "name": "Lore",
-    "url": "/api/subclasses/lore",
+      "index": "lore",
+      "name": "Lore",
+      "url": "/api/subclasses/lore",
     }
   ],
-  }</code></pre>
+}</code></pre>
 
 <h4>Subclasses for Class</h4>
 
@@ -215,7 +216,7 @@
       <td align="left">results</td>
       <td align="left">A list of subclasses available to a class</td>
       <td align="left">
-        list <a href="#namedapiresource">NamedAPIResource</a> (<a href="#subclass">Subclass</a>)
+        list <a href="#apireference">APIReference</a> (<a href="#subclass">Subclass</a>)
       </td>
     </tr>
   </thead>
@@ -348,7 +349,7 @@
       <td align="left">class</td>
       <td align="left">The class which this level refers to.</td>
       <td align="left">
-        <a href="#namedapiresource">NamedAPIResource</a> (<a href="#class">Class</a>) Updated
+        <a href="#apireference">APIReference</a> (<a href="#class">Class</a>) Updated
         ability scores, classes, and conditions
       </td>
     </tr>
@@ -357,7 +358,7 @@
       <td align="left">starting_equipment</td>
       <td align="left">The starting equipment a character automatically gets</td>
       <td align="left">
-        list <a href="#namedapiresource">NamedAPIResource</a> (<a href="#equipment">Equipment</a>)
+        list <a href="#apireference">APIReference</a> (<a href="#equipment">Equipment</a>)
       </td>
     </tr>
 
@@ -383,27 +384,29 @@
 <pre><code>{
   "index": "bard",
   "class": {
-    "url": "/api/classes/bard",
-    "name": "Bard"
+    "index": "bard",
+    "name": "Bard",
+    "url": "/api/classes/bard"
   },
   "level": 1,
   "spellcasting_ability": {
-    "url": "/api/ability-scores/cha",
+    "index": "cha",
     "name": "CHA",
+    "url": "/api/ability-scores/cha"
   },
   "info": [
     {
       "name": "Cantrips",
       "desc": [
         "You know two cantrips of your choice from the bard spell list. You learn additional bard cantrips of your choice at higher levels, as shown in the Cantrips Known column of the Bard table."
-      ],
+      ]
     },
     {
       "name": "Spell Slots",
       "desc": [
         "The Bard table shows how many spell slots you have to cast your spells of 1st level and higher. To cast one of these spells, you must expend a slot of the spell's level or higher. You regain all expended spell slots when you finish a long rest.",
-        "For example, if you know the 1st-level spell cure wounds and have a 1st-level and a 2nd-level spell slot available, you can cast cure wounds using either slot.",
-      ],
+        "For example, if you know the 1st-level spell cure wounds and have a 1st-level and a 2nd-level spell slot available, you can cast cure wounds using either slot."
+      ]
     },
     {
       "name": "Spells Known of 1st Level and Higher",
@@ -411,31 +414,31 @@
         "You know four 1st-level spells of your choice from the bard spell list.",
         "The Spells Known column of the Bard table shows when you learn more bard spells of your choice.",
         "Each of these spells must be of a level for which you have spell slots, as shown on the table. For instance, when you reach 3rd level in this class, you can learn one new spell of 1st or 2nd level.",
-        "Additionally, when you gain a level in this class, you can choose one of the bard spells you know and replace it with another spell from the bard spell list, which also must be of a level for which you have spell slots.",
-      ],
+        "Additionally, when you gain a level in this class, you can choose one of the bard spells you know and replace it with another spell from the bard spell list, which also must be of a level for which you have spell slots."
+      ]
     },
     {
       "name": "Spellcasting Ability",
       "desc": [
         "Charisma is your spellcasting ability for your bard spells. Your magic comes from the heart and soul you pour into the performance of your music or oration. You use your Charisma whenever a spell refers to your spellcasting ability. In addition, you use your Charisma modifier when setting the saving throw DC for a bard spell you cast and when making an attack roll with one.",
         "Spell save DC = 8 + your proficiency bonus + your Charisma modifier.",
-        "Spell attack modifier = your proficiency bonus + your Charisma modifier.",
-      ],
+        "Spell attack modifier = your proficiency bonus + your Charisma modifier."
+      ]
     },
     {
       "name": "Ritual Casting",
       "desc": [
         "You can cast any bard spell you know as a ritual if that spell has the ritual tag."
-      ],
+      ]
     },
     {
       "name": "Spellcasting Focus",
       "desc": [
         "You can use a musical instrument (see Equipment) as a spellcasting focus for your bard spells."
-      ],
-    },
+      ]
+    }
   ],
-  "url": "/api/spellcasting/bard",
+  "url": "/api/spellcasting/bard"
 }</code></pre>
 
 <h4>Spellcasting for Class</h4>
@@ -459,7 +462,7 @@
       <td align="left">class</td>
       <td align="left">The class which this level refers to.</td>
       <td align="left">
-        <a href="#namedapiresource">NamedAPIResource</a> (<a href="#class">Class</a>) Updated
+        <a href="#apireference">APIReference</a> (<a href="#class">Class</a>) Updated
         ability scores, classes, and conditions
       </td>
     </tr>
@@ -474,7 +477,7 @@
       <td align="left">spellcasting_ability</td>
       <td align="left">The attribute used by the spellcasting class</td>
       <td align="left">
-        <a href="#namedapiresource">NamedAPIResource</a> (<a href="#spells">Spells</a>)
+        <a href="#apireference">APIReference</a> (<a href="#spells">Spells</a>)
       </td>
     </tr>
 
@@ -494,7 +497,7 @@
 
 <h3>GET api/classes/{index}/spells/</h3>
 
-<pre><code>
+<pre><code>{
   "count": 111,
   "results": [
     {
@@ -531,7 +534,7 @@
       <td align="left">results</td>
       <td align="left">A list of the spells available to a class</td>
       <td align="left">
-        list <a href="#namedapiresource">NamedAPIResource</a> (<a href="#spells">Spells</a>)
+        list <a href="#apireference">APIReference</a> (<a href="#spells">Spells</a>)
       </td>
     </tr>
   </tbody>
@@ -577,7 +580,7 @@
         <td align="left">results</td>
         <td align="left">A list of features available to a class</td>
         <td align="left">
-          list <a href="#namedapiresource">NamedAPIResource</a> (<a href="#features">Features</a>)
+          list <a href="#apireference">APIReference</a> (<a href="#features">Features</a>)
         </td>
       </tr>
     </tbody>
@@ -624,7 +627,7 @@
         <td align="left">results</td>
         <td align="left">A list of proficiencies available to a class</td>
         <td align="left">
-          list <a href="#namedapiresource">NamedAPIResource</a> (<a href="#proficiencies">Proficiencies</a>)
+          list <a href="#apireference">APIReference</a> (<a href="#proficiencies">Proficiencies</a>)
         </td>
       </tr>
     </tbody>
@@ -641,10 +644,12 @@
     "feature_choices": [],
     "features": [
       {
+        "index": "spellcasting-bard",
         "name": "Spellcasting",
         "url": "/api/features/spellcasting-bard"
       },
       {
+        "index": "bardic-inspiration-d6",
         "name": "Bardic Inspiration (d6)",
         "url": "/api/features/bardic-inspiration-d6"
       }
@@ -672,6 +677,7 @@
     "index": "bard-1",
     "class": {
       "name": "Bard",
+      "index": "bard",
       "url": "/api/classes/bard"
     },
     "url": "/api/classes/bard/levels/1"
@@ -684,6 +690,7 @@
     "feature_choices": [],
     "features": [
       {
+        "index": "superior-inspiration",
         "name": "Superior Inspiration",
         "url": "/api/features/superior-inspiration"
       }
@@ -711,6 +718,7 @@
     "index": "bard-20",
     "class": {
       "name": "Bard",
+      "index": "bard",
       "url": "/api/classes/bard"
     },
     "url": "/api/classes/bard/levels/20"
@@ -756,22 +764,20 @@
         Special features which require a player to choose a new feature to be added.
       </td>
       <td align="left">
-        list <a href="#namedapiresource">NamedAPIResource</a> (<a href="#features">Features</a>)
+        list <a href="#apireference">APIReference</a> (<a href="#features">Features</a>)
       </td>
     </tr>
     <tr>
       <td align="left">features</td>
       <td align="left">Features automatically gained by players at this level.</td>
       <td align="left">
-        list <a href="#namedapiresource">NamedAPIResource</a> (<a href="#features">Features</a>)
+        list <a href="#apireference">APIReference</a> (<a href="#features">Features</a>)
       </td>
     </tr>
     <tr>
       <td align="left">spellcasting</td>
       <td align="left">spells known, spellcasting ability, and cantrips known.</td>
-      <td align="left">
-        <a href="#classapiresource">ClassAPIResource</a> (<a href="#spellcasting">Spellcasting</a>)
-      </td>
+      <td align="left"> object </td>
     </tr>
     <tr>
       <td align="left">class_specific</td>
@@ -785,7 +791,7 @@
       <td align="left">class</td>
       <td align="left">The class which this level refers to.</td>
       <td align="left">
-        <a href="#namedapiresource">NamedAPIResource</a> (<a href="#class">Class</a>) Updated
+        <a href="#apireference">APIReference</a> (<a href="#class">Class</a>) Updated
         ability scores, classes, and conditions
       </td>
     </tr>
@@ -881,21 +887,21 @@
         Special features which require a player to choose a new feature to be added.
       </td>
       <td align="left">
-        list <a href="#namedapiresource">NamedAPIResource</a> (<a href="#features">Features</a>)
+        list <a href="#apireference">APIReference</a> (<a href="#features">Features</a>)
       </td>
     </tr>
     <tr>
       <td align="left">features</td>
       <td align="left">Features automatically gained by players at this level.</td>
       <td align="left">
-        list <a href="#namedapiresource">NamedAPIResource</a> (<a href="#features">Features</a>)
+        list <a href="#apireference">APIReference</a> (<a href="#features">Features</a>)
       </td>
     </tr>
     <tr>
       <td align="left">spellcasting</td>
       <td align="left">spells known, spellcasting ability, and cantrips known.</td>
       <td align="left">
-        <a href="#classapiresource">ClassAPIResource</a> (<a href="#spellcasting">Spellcasting</a>)
+        object
       </td>
     </tr>
     <tr>
@@ -910,7 +916,7 @@
       <td align="left">class</td>
       <td align="left">The class which this level refers to.</td>
       <td align="left">
-        <a href="#namedapiresource">NamedAPIResource</a> (<a href="#class">Class</a>) Updated
+        <a href="#apireference">APIReference</a> (<a href="#class">Class</a>) Updated
         ability scores, classes, and conditions
       </td>
     </tr>
@@ -961,7 +967,7 @@
         <td align="left">results</td>
         <td align="left">A list of features available to a class at the requested level</td>
         <td align="left">
-          list <a href="#namedapiresource">NamedAPIResource</a> (<a href="#features">Features</a>)
+          list <a href="#apireference">APIReference</a> (<a href="#features">Features</a>)
         </td>
       </tr>
     </tbody>
@@ -1007,7 +1013,7 @@
         <td align="left">results</td>
         <td align="left">A list of spells availabe to a class at the specified level</td>
         <td align="left">
-          list <a href="#namedapiresource">NamedAPIResource</a> (<a href="#spells">Spells</a>)
+          list <a href="#apireference">APIReference</a> (<a href="#spells">Spells</a>)
         </td>
       </tr>
     </tbody>

--- a/src/views/partials/doc-resource-common-models.ejs
+++ b/src/views/partials/doc-resource-common-models.ejs
@@ -1,6 +1,6 @@
 <h2 id="common-models">Common Models</h2>
 
-<h4 id="namedapiresource">NamedAPIResource</h4>
+<h4 id="apireference">APIReference</h4>
 <table>
   <thead>
     <tr>
@@ -79,7 +79,7 @@
     <tr>
       <td align="left">from</td>
       <td align="left">A list of resources to choose from</td>
-      <td align="left">list <a href="#apiresource">APIResource</a></td>
+      <td align="left">list <a href="#apireference">APIReference</a></td>
     </tr>
   </tbody>
 </table>

--- a/src/views/partials/doc-resource-equipment-categories.ejs
+++ b/src/views/partials/doc-resource-equipment-categories.ejs
@@ -51,7 +51,7 @@
       <td align="left">equipment</td>
       <td align="left">A list of the equipment that falls into this category</td>
       <td align="left">list
-        <a href="#namedapiresource">NamedAPIResource</a> (<a href="#equipment-categories"
+        <a href="#apireference">APIReference</a> (<a href="#equipment-categories"
           >Equipment Categories</a
         >)
       </td>

--- a/src/views/partials/doc-resource-equipment.ejs
+++ b/src/views/partials/doc-resource-equipment.ejs
@@ -26,8 +26,9 @@
   "damage": {
     "damage_dice": "1d4",
     "damage_type": {
-      "url": "/api/damage-types/bludgeoning",
-      "name": "Bludgeoning"
+      "name": "Bludgeoning",
+      "index": "bludgeoning",
+      "url": "/api/damage-types/bludgeoning"
     }
   },
   "range": {
@@ -37,12 +38,14 @@
   "weight": 2,
   "properties": [
     {
-      "url": "/api/weapon-properties/light",
-      "name": "Light"
+      "name": "Light",
+      "index": "light",
+      "url": "/api/weapon-properties/light"
     },
     {
-      "url": "/api/weapon-properties/monk",
-      "name": "Monk"
+      "name": "Monk",
+      "index": "light",
+      "url": "/api/weapon-properties/monk"
     }
   ],
   "url": "/api/equipment/club"
@@ -72,7 +75,7 @@
       <td align="left">equipment_category</td>
       <td align="left">The category of equipment this falls into</td>
       <td align="left">
-        list <a href="#namedapiresource">NamedAPIResource</a> (<a href="#equipment-categories">Equipment Categories</a>)
+        list <a href="#apireference">APIReference</a> (<a href="#equipment-categories">Equipment Categories</a>)
       </td>
     </tr>
     <tr>
@@ -116,7 +119,7 @@
       <td align="left">properties</td>
       <td align="left">A list of the properties this weapon has</td>
       <td align="left">list
-        <a href="#namedapiresource">NamedAPIResource</a> (<a href="#weapon-properties"
+        <a href="#apireference">APIReference</a> (<a href="#weapon-properties"
           >Weapon Properties</a
         >)
       </td>
@@ -137,7 +140,8 @@
   "name": "Padded",
   "equipment_category": {
     "name": "Armor",
-    "url": "/api/equipment-categories/armor",
+    "index": "armor",
+    "url": "/api/equipment-categories/armor"
     },
   "armor_category": "Light",
   "armor_class": {
@@ -179,7 +183,7 @@
       <td align="left">equipment_category</td>
       <td align="left">The category of equipment this falls into</td>
       <td align="left">
-        list <a href="#namedapiresource">NamedAPIResource</a> (<a href="#equipment-categories">Equipment Categories</a>)
+        list <a href="#apireference">APIReference</a> (<a href="#equipment-categories">Equipment Categories</a>)
       </td>
     </tr>
     <tr>

--- a/src/views/partials/doc-resource-features.ejs
+++ b/src/views/partials/doc-resource-features.ejs
@@ -10,8 +10,9 @@
 <pre><code>{
   "index": "action-surge-1-use",
   "class": {
-    "url": "/api/classes/fighter",
-    "name": "Fighter"
+    "name": "Fighter",
+    "index": "fighter",
+    "url": "/api/classes/fighter"
   },
   "name": "Action Surge (1 use)",
   "level": 2,
@@ -52,14 +53,14 @@
       <td align="left">class</td>
       <td align="left">The class that gains this feature.</td>
       <td align="left">
-        <a href="#namedapiresource">NamedAPIResource</a> (<a href="#classes">Class</a>)
+        <a href="#apireference">APIReference</a> (<a href="#classes">Class</a>)
       </td>
     </tr>
     <tr>
       <td align="left">subclass</td>
       <td align="left">The subclass that gains feature resource</td>
       <td align="left">
-        <a href="#namedapiresource">NamedAPIResource</a> (<a href="#subclasses">Subclass</a>)
+        <a href="#apireference">APIReference</a> (<a href="#subclasses">Subclass</a>)
       </td>
     </tr>
     <tr>

--- a/src/views/partials/doc-resource-lists.ejs
+++ b/src/views/partials/doc-resource-lists.ejs
@@ -73,7 +73,7 @@
   </tbody>
 </table>
 
-<h4>NamedAPIResourceList</h4>
+<h4>APIReferenceList</h4>
 
 <table>
   <thead>
@@ -92,7 +92,7 @@
     <tr>
       <td align="left">results</td>
       <td align="left">A list of named API resource lists</td>
-      <td align="left">list <a href="#namedapiresource">NamedAPIResource</a></td>
+      <td align="left">list <a href="#apireference">APIReference</a></td>
     </tr>
   </tbody>
 </table>
@@ -101,22 +101,22 @@
   "count": 8,
   "results": [
     {
-      "index": 1,
+      "index": "bard",
       "class": "Bard",
       "url": "/api/spellcasting/bard"
     },
     {
-      "index": 2,
+      "index": "cleric",
       "class": "Cleric",
       "url": "/api/spellcasting/cleric" 
     },
     {
-      "index": 3,
+      "index": "druid",
       "class": "Druid",
       "url": "/api/spellcasting/druid"
     },
     {
-      "index": 4,
+      "index": "paladin",
       "class": "Paladin",
       "url": "/api/spellcasting/paladin"
     },

--- a/src/views/partials/doc-resource-proficiencies.ejs
+++ b/src/views/partials/doc-resource-proficiencies.ejs
@@ -9,29 +9,34 @@
   "name": "Medium armor",
   "classes": [
     {
-      "url": "/api/classes/barbarian",
-      "name": "Barbarian"
+      "name": "Barbarian",
+      "index": "barbarian",
+      "url": "/api/classes/barbarian"
     },
     {
-      "url": "/api/classes/cleric",
-      "name": "Cleric"
+      "name": "Cleric",
+      "index": "cleric",
+      "url": "/api/classes/cleric"
     },
     {
-      "url": "/api/classes/druid",
-      "name": "Druid"
+      "name": "Druid",
+      "index": "druid",
+      "url": "/api/classes/druid"
     },
     {
+      "name": "Ranger",
+      "index": "ranger",
       "url": "/api/classes/ranger",
-      "name": "Ranger"
     }
   ],
   "races": [],
   "url": "/api/proficiencies/medium-armor",
-  references: [
+  "references": [
     {
-    url: "/api/equipment-categories/medium-armor",
-    type: "equipment-categories",
-    name: "Medium armor",
+      "name": "Medium armor",
+      "index": "medium-armor",
+      "type": "equipment-categories",
+      "url": "/api/equipment-categories/medium-armor"
     }
   ],
 }</code></pre>
@@ -66,14 +71,14 @@
       <td align="left">classes</td>
       <td align="left">Classes that start with this proficiency.</td>
       <td align="left">
-        list <a href="#namedapiresource">NamedAPIResource</a> (<a href="#classes">Class</a>)
+        list <a href="#apireference">APIReference</a> (<a href="#classes">Class</a>)
       </td>
     </tr>
     <tr>
       <td align="left">races</td>
       <td align="left">Races that start with this proficiency.</td>
       <td align="left">
-        list <a href="#namedapiresource">NamedAPIResource</a> (<a href="#races">Race</a>)
+        list <a href="#apireference">APIReference</a> (<a href="#races">Race</a>)
       </td>
     </tr>
     <tr>
@@ -85,7 +90,7 @@
       <td align="left">references</td>
       <td align="left">list of references</td>
       <td align="left">
-        list <a href="#namedapiresource">NamedAPIResource</a> (<a href="#equipment-categories">Equipment Categories</a>)
+        list <a href="#apireference">APIReference</a> (<a href="#equipment-categories">Equipment Categories</a>)
       </td>
     </tr>
   </tbody>

--- a/src/views/partials/doc-resource-races.ejs
+++ b/src/views/partials/doc-resource-races.ejs
@@ -10,8 +10,9 @@
   "ability_bonuses": [
     {
       "name": "CON",
-      "url": "/api/ability-scores/con",
-      "bonus": 2
+      "index": "con",
+      "bonus": 2,
+      "url": "/api/ability-scores/con"
     }
   ],
   "alignment": "Most dwarves are lawful, believing firmly in the benefits of a well-ordered society. They tend toward good as well, with a strong sense of fair play and a belief that everyone deserves to share in the benefits of a just order.",
@@ -20,20 +21,24 @@
   "size_description": "Dwarves stand between 4 and 5 feet tall and average about 150 pounds. Your size is Medium.",
   "starting_proficiencies": [
     {
-      "url": "/api/proficiencies/battleaxes",
-      "name": "Battleaxes"
+      "name": "Battleaxes",
+      "index": "battleaxes",
+      "url": "/api/proficiencies/battleaxes"
     },
     {
-      "url": "/api/proficiencies/handaxes",
-      "name": "Handaxes"
+      "name": "Handaxes",
+      "index": "handaxes",
+      "url": "/api/proficiencies/handaxes"
     },
     {
-      "url": "/api/proficiencies/light-hammers",
-      "name": "Light hammers"
+      "name": "Light hammers",
+      "index": "light-hammers",
+      "url": "/api/proficiencies/light-hammers"
     },
     {
-      "url": "/api/proficiencies/warhammers",
-      "name": "Warhammers"
+      "name": "Warhammers",
+      "index": "warhammers",
+      "url": "/api/proficiencies/warhammers"
     }
   ],
   "starting_proficiency_options": {
@@ -41,51 +46,61 @@
     "type": "proficiencies",
     "from": [
       {
-        "url": "/api/proficiencies/smiths-tools",
-        "name": "Smith's tools"
+        "name": "Smith's tools",
+        "index": "smiths-tools",
+        "url": "/api/proficiencies/smiths-tools"
       },
       {
+        "name": "Brewer's supplies",
+        "index": "brewers-supplies",
         "url": "/api/proficiencies/brewers-supplies",
-        "name": "Brewer's supplies"
       },
       {
-        "url": "/api/proficiencies/masons-tools",
-        "name": "Mason's tools"
+        "name": "Mason's tools",
+        "index": "masons-tools",
+        "url": "/api/proficiencies/masons-tools"
       }
     ]
   },
   "languages": [
     {
-      "url": "/api/languages/common",
-      "name": "Common"
+      "name": "Common",
+      "index": "common",
+      "url": "/api/languages/common"
     },
     {
-      "url": "/api/languages/dwarvish",
-      "name": "Dwarvish"
+      "name": "Dwarvish",
+      "index": "dwarvish",
+      "url": "/api/languages/dwarvish"
     }
   ],
   "language_desc": "You can speak, read, and write Common and Dwarvish. Dwarvish is full of hard consonants and guttural sounds, and those characteristics spill over into whatever other language a dwarf might speak.",
   "traits": [
     {
       "name": "Darkvision",
+      "index": "darkvision",
       "url": "/api/traits/darkvision"
     },
     {
       "name": "Dwarven Resilience",
+      "index": "dwarven-resilience",
       "url": "/api/traits/dwarven-resilience"
     },
     {
       "name": "Stonecunning",
+      "index": "stonecunning",
       "url": "/api/traits/stonecunning"
     }
     {
       "name": "Dwarven Combat Training",
+      "index": "dwarven-combat-training",
       "url": "/api/traits/dwarven-combat-training"
     }
   ],
   "subraces": [
     {
       "url": "/api/subraces/hill-dwarf",
+      "index": "hill-dwarf",
       "name": "Hill Dwarf"
     }
   ],
@@ -147,7 +162,7 @@
       <td align="left">starting_proficiencies</td>
       <td align="left">Starting proficiencies for all new characters of this race</td>
       <td align="left">
-        list <a href="#namedapiresource">NamedAPIResource</a> (<a href="#proficiencies"
+        list <a href="#apireference">APIReference</a> (<a href="#proficiencies"
           >Proficiencies</a
         >)
       </td>
@@ -156,7 +171,7 @@
       <td align="left">languages</td>
       <td align="left">Starting languages for all new characters of this race</td>
       <td align="left">
-        list <a href="#namedapiresource">NamedAPIResource</a> (<a href="#languages">Proficiencies</a
+        list <a href="#apireference">APIReference</a> (<a href="#languages">Proficiencies</a
         >)
       </td>
     </tr>
@@ -169,7 +184,7 @@
       <td align="left">traits</td>
       <td align="left">Racial traits that provide benefits to its members</td>
       <td align="left">
-        list <a href="#namedapiresource">NamedAPIResource</a> (<a href="#traits">Trait</a>)
+        list <a href="#apireference">APIReference</a> (<a href="#traits">Trait</a>)
       </td>
     </tr>
     <tr>
@@ -179,7 +194,7 @@
         known, spellcasting ability, and cantrips known.
       </td>
       <td align="left">
-        <a href="#namedapiresource">NamedAPIResource</a> (<a href="#subraces">Subrace</a>)
+        <a href="#apireference">APIReference</a> (<a href="#subraces">Subrace</a>)
       </td>
     </tr>
     <tr>
@@ -224,7 +239,7 @@
       <td align="left">results</td>
       <td align="left">A list of the subrace and its reference url</td>
       <td align="left">
-        list <a href="#namedapiresource">NamedAPIResource</a> (<a href="#subraces">Subrace</a>)
+        list <a href="#apireference">APIReference</a> (<a href="#subraces">Subrace</a>)
       </td>
     </tr>
   </tbody>
@@ -264,7 +279,7 @@
       <td align="left">results</td>
       <td align="left">A list of the available proficiencies for a race</td>
       <td align="left">
-        list <a href="#namedapiresource">NamedAPIResource</a> (<a href="#proficiencies">Proficiencies</a>)
+        list <a href="#apireference">APIReference</a> (<a href="#proficiencies">Proficiencies</a>)
       </td>
     </tr>
   </tbody>
@@ -310,7 +325,7 @@
       <td align="left">results</td>
       <td align="left">A list of the available traits for a race</td>
       <td align="left">
-        list <a href="#namedapiresource">NamedAPIResource</a> (<a href="#traits">Traits</a>)
+        list <a href="#apireference">APIReference</a> (<a href="#traits">Traits</a>)
       </td>
     </tr>
   </tbody>

--- a/src/views/partials/doc-resource-skills.ejs
+++ b/src/views/partials/doc-resource-skills.ejs
@@ -14,8 +14,9 @@
     "Your Intelligence (Arcana) check measures your ability to recall lore about spells, magic items, eldritch symbols, magical traditions, the planes of existence, and the inhabitants of those planes."
   ],
   "ability_score": {
-    "url": "/api/ability-scores/int",
-    "name": "INT"
+    "name": "INT",
+    "index": "int",
+    "url": "/api/ability-scores/int"
   },
   "url": "/api/skills/arcana"
 }</code></pre>
@@ -50,7 +51,7 @@
       <td align="left">ability_score</td>
       <td align="left">The ability score associated with this skill.</td>
       <td align="left">
-        list <a href="#namedapiresource">NamedAPIResource</a> (<a href="#ability-scores"
+        list <a href="#apireference">APIReference</a> (<a href="#ability-scores"
           >Ability Score</a
         >)
       </td>

--- a/src/views/partials/doc-resource-spells.ejs
+++ b/src/views/partials/doc-resource-spells.ejs
@@ -29,39 +29,44 @@
   "attack_type": "ranged",
 
   "damage": {
-    damage_type: {
-      name: "Acid",
-      url: "/api/damage-types/acid",
+    "damage_type": {
+      "name": "Acid",
+      "index": "acid",
+      "url": "/api/damage-types/acid"
     },
-    damage_at_slot_level: {
-      2: "4d4",
-      3: "5d4",
-      4: "6d4",
-      5: "7d4",
-      6: "8d4",
-      7: "9d4",
-      8: "10d4",
-      9: "11d4",
+    "damage_at_slot_level": {
+      "2": "4d4",
+      "3": "5d4",
+      "4": "6d4",
+      "5": "7d4",
+      "6": "8d4",
+      "7": "9d4",
+      "8": "10d4",
+      "9": "11d4",
     },
   },
 
   "school": {
     "name": "Evocation",
+    "index": "evocation",
     "url": "/api/magic-schools/evocation"
   },
   "classes": [
     {
       "name": "Wizard",
+      "index": "wizard",
       "url": "/api/classes/wizard"
     }
   ],
   "subclasses": [
     {
       "name": "Lore",
+      "index": "lore",
       "url": "/api/subclasses/lore"
     },
     {
       "name": "Land",
+      "index": "land",
       "url": "/api/subclasses/land"
     }
   ],
@@ -159,19 +164,19 @@
     <tr>
       <td align="left">school</td>
       <td align="left">The magic school this spell belongs to</td>
-      <td align="left"><a href="#namedapiresource">NamedAPIResource</a> (<a href="#magic-schools">Magic Schools</a>)</td>
+      <td align="left"><a href="#apireference">APIReference</a> (<a href="#magic-schools">Magic Schools</a>)</td>
     </tr>
 
     <tr>
       <td align="left">classes</td>
       <td align="left">The classes that are able to learn this spell</td>
-      <td align="left"><a href="#namedapiresource">NamedAPIResource</a> (<a href="#classes">Classes</a>)</td>
+      <td align="left"><a href="#apireference">APIReference</a> (<a href="#classes">Classes</a>)</td>
     </tr>
 
     <tr>
       <td align="left">subclasses</td>
       <td align="left">A list of subclasses that have access to this spell</td>
-      <td align="left">list<a href="#namedapiresource">NamedAPIResource</a> (<a href="#classes">Classes</a>)</td>
+      <td align="left">list<a href="#apireference">APIReference</a> (<a href="#classes">Classes</a>)</td>
     </tr>
 
     <tr>

--- a/src/views/partials/doc-resource-subclasses.ejs
+++ b/src/views/partials/doc-resource-subclasses.ejs
@@ -6,8 +6,9 @@
 <pre><code>{
   "index": "devotion",
   "class": {
-    "url": "/api/classes/paladin",
-    "name": "Paladin"
+    "index": "paladin",
+    "name": "Paladin",
+    "url": "/api/classes/paladin"
   },
   "name": "Devotion",
   "subclass_flavor": "Sacred Oath",
@@ -16,127 +17,143 @@
   ],
   "spells": [
     {
-      prerequisites: [
+      "prerequisites": [
         {
-          name: "Paladin 3",
-          type: "level",
-          url: "/api/classes/paladin/levels/3",
+          "index": "paladin-3",
+          "type": "level",
+          "name": "Paladin 3",
+          "url": "/api/classes/paladin/levels/3"
         }
       ],
-      spell: {
-        url: "/api/spells/protection-from-evil-and-good",
-        name: "Protection from Evil and Good",
-      },
+      "spell": {
+        "index": "protection-from-evil-and-good",
+        "name": "Protection from Evil and Good",
+        "url": "/api/spells/protection-from-evil-and-good"
+      }
     },
     {
-      prerequisites: [
+      "prerequisites": [
         {
-          name: "Paladin 3",
-          type: "level",
-          url: "/api/classes/paladin/levels/3",
+          "index": "paladin-3",
+          "type": "level",
+          "name": "Paladin 3",
+          "url": "/api/classes/paladin/levels/3"
         }
       ],
-      spell: {
-        url: "/api/spells/sanctuary",
-        name: "Sanctuary",
-      },
+      "spell": {
+        "index": "sanctuary",
+        "name": "Sanctuary",
+        "url": "/api/spells/sanctuary"
+      }
     },
     {
-      prerequisites: [
+      "prerequisites": [
         {
-          name: "Paladin 5",
-          type: "level",
-          url: "/api/classes/paladin/levels/5",
+          "index": "paladin-5",
+          "type": "level",
+          "name": "Paladin 5",
+          "url": "/api/classes/paladin/levels/5"
         }
       ],
-      spell: {
-        url: "/api/spells/lesser-restoration",
-        name: "Lesser Restoration",
-      },
+      "spell": {
+        "index": "lesser-restoration",
+        "name": "Lesser Restoration",
+        "url": "/api/spells/lesser-restoration"
+      }
     },
     {
-      prerequisites: [
+      "prerequisites": [
         {
-          name: "Paladin 5",
-          type: "level",
-          url: "/api/classes/paladin/levels/5",
+          "index": "paladin-5",
+          "type": "level",
+          "name": "Paladin 5",
+          "url": "/api/classes/paladin/levels/5"
         }
       ],
-      spell: {
-        url: "/api/spells/zone-of-truth",
-        name: "Zone of Truth",
-      },
+      "spell": {
+        "index": "zone-of-truth",
+        "name": "Zone of Truth",
+        "url": "/api/spells/zone-of-truth"
+      }
     },
     {
-      prerequisites: [
+      "prerequisites": [
         {
-          name: "Paladin 9",
-          type: "level",
-          url: "/api/classes/paladin/levels/9",
+          "index": "paladin-9",
+          "type": "level",
+          "name": "Paladin 9",
+          "url": "/api/classes/paladin/levels/9"
         }
       ],
-      spell: {
-        url: "/api/spells/beacon-of-hope",
-        name: "Beacon of Hope",
-      },
+      "spell": {
+        "index": "beacon-of-hope",
+        "name": "Beacon of Hope",
+        "url": "/api/spells/beacon-of-hope"
+      }
     },
     {
-      prerequisites: [
+      "prerequisites": [
         {
-          name: "Paladin 9",
-          type: "level",
-          url: "/api/classes/paladin/levels/9",
+          "index": "paladin-9",
+          "type": "level",
+          "name": "Paladin 9",
+          "url": "/api/classes/paladin/levels/9"
         }
       ],
-      spell: {
-        url: "/api/spells/dispel-magic",
-        name: "Dispel Magic",
-      },
+      "spell": {
+        "index": "dispel-magic",
+        "name": "Dispel Magic",
+        "url": "/api/spells/dispel-magic"
+      }
     },
     {
-      prerequisites: [
+      "prerequisites": [
         {
-          name: "Paladin 13",
-          type: "level",
-          url: "/api/classes/paladin/levels/13",
+          "index": "paladin-13",
+          "type": "level",
+          "name": "Paladin 13",
+          "url": "/api/classes/paladin/levels/13"
         }
       ],
-      spell: {
-        url: "/api/spells/freedom-of-movement",
-        name: "Freedom of Movement",
-      },
+      "spell": {
+        "index": "freedom-of-movement",
+        "name": "Freedom of Movement",
+        "url": "/api/spells/freedom-of-movement"
+      }
     },
     {
-      prerequisites: [
+      "prerequisites": [
         {
-          name: "Paladin 17",
-          type: "level",
-          url: "/api/classes/paladin/levels/17",
+          "index": "paladin-17",
+          "type": "level",
+          "name": "Paladin 17",
+          "url": "/api/classes/paladin/levels/17"
         }
       ],
-      spell: {
-        url: "/api/spells/commune",
-        name: "Commune",
-      },
+      "spell": {
+        "index": "commune",
+        "name": "Commune",
+        "url": "/api/spells/commune"
+      }
     },
     {
-      prerequisites: [
+      "prerequisites": [
         {
-          name: "Paladin 17",
-          type: "level",
-          url: "/api/classes/paladin/levels/17",
+          "index": "paladin-17",
+          "type": "level",
+          "name": "Paladin 17",
+          "url": "/api/classes/paladin/levels/17"
         }
       ],
-      spell: {
-        url: "/api/spells/flame-strike",
-        name: "Flame Strike",
-      },
-    },
+      "spell": {
+        "index": "flame-strike",
+        "name": "Flame Strike",
+        "url": "/api/spells/flame-strike"
+      }
+    }
   ],
-  "subclass_levels": {
-    url: "/api/subclasses/devotion/levels"
-  }
-  "url": "/api/subclasses/champion"
+  "subclass_levels": "/api/subclasses/devotion/levels",
+  "url": "/api/subclasses/devotion"
 }</code></pre>
 
 <h4>Subclass</h4>
@@ -159,7 +176,7 @@
       <td align="left">class</td>
       <td align="left">The parent class for this subclass.</td>
       <td align="left">
-        <a href="#namedapiresource">NamedAPIResource</a> (<a href="#classes">Class</a>)
+        <a href="#apireference">APIReference</a> (<a href="#classes">Class</a>)
       </td>
     </tr>
     <tr>
@@ -186,7 +203,7 @@
       <td align="left">subclass_levels</td>
       <td align="left">A resource url that shows the subclass level progression </td>
       <td align="left">
-        <a href="#namedapiresource">NamedAPIResource</a> (<a href="#levels">Levels</a>)
+        <a href="#apireference">APIReference</a> (<a href="#levels">Levels</a>)
       </td>
     </tr>
     <tr>
@@ -237,7 +254,7 @@
       <td align="left">results</td>
       <td align="left">A list of the available features for a subclass</td>
       <td align="left">
-        list <a href="#namedapiresource">NamedAPIResource</a> (<a href="#features">Features</a>)
+        list <a href="#apireference">APIReference</a> (<a href="#features">Features</a>)
       </td>
     </tr>
   </tbody>
@@ -252,19 +269,23 @@
     "features": [
       {
         "name": "Primal Path",
+        "index": "primal-path",
         "url": "/api/features/primal-path"
       },
       {
         "name": "Frenzy",
+        "index": "frenzy",
         "url": "/api/features/frenzy"
       }
     ],
     "class": {
       "name": "Barbarian",
+      "index": "barbarian",
       "url": "/api/classes/barbarian"
     },
     "subclass": {
       "name": "Berserker",
+      "index": "berserker",
       "url": "/api/subclasses/berserker"
     },
     "url": "/api/subclasses/berserker/levels/3",
@@ -273,21 +294,22 @@
   ...
   {
     "level": 14,
-    "feature_choices": [
-
-    ],
+    "feature_choices": [],
     "features": [
       {
         "name": "Retaliation",
+        "index": "retaliation",
         "url": "/api/features/retaliation"
       }
     ],
     "class": {
       "name": "Barbarian",
+      "index": "barbarian",
       "url": "/api/classes/barbarian"
     },
     "subclass": {
       "name": "Berserker",
+      "index": "berserker",
       "url": "/api/subclasses/berserker"
     },
     "url": "/api/subclasses/berserker/levels/14",
@@ -316,7 +338,7 @@
       <td align="left">feature_choices</td>
       <td align="left">A list of the available feature choices for a subclass</td>
       <td align="left">
-        list <a href="#namedapiresource">NamedAPIResource</a> (<a href="#features">Features</a>)
+        list <a href="#apireference">APIReference</a> (<a href="#features">Features</a>)
       </td>
     </tr>
 
@@ -324,7 +346,7 @@
       <td align="left">features</td>
       <td align="left">The feature available for a subclass</td>
       <td align="left">
-        list <a href="#namedapiresource">NamedAPIResource</a> (<a href="#features">Features</a>)
+        list <a href="#apireference">APIReference</a> (<a href="#features">Features</a>)
       </td>
     </tr>
 
@@ -332,7 +354,7 @@
       <td align="left">classes</td>
       <td align="left">The class that has access to subclass feature</td>
       <td align="left">
-        list <a href="#namedapiresource">NamedAPIResource</a> (<a href="#classes">Classes</a>)
+        list <a href="#apireference">APIReference</a> (<a href="#classes">Classes</a>)
       </td>
     </tr>
 
@@ -340,7 +362,7 @@
       <td align="left">subclass</td>
       <td align="left">The subclass name</td>
       <td align="left">
-        list <a href="#namedapiresource">NamedAPIResource</a> (<a href="#subclasses">Subclasses</a>)
+        list <a href="#apireference">APIReference</a> (<a href="#subclasses">Subclasses</a>)
       </td>
     </tr>
     <tr>
@@ -361,25 +383,27 @@
 
 <pre><code>{
   "level": 3,
-  "feature_choices": [
-
-  ],
+  "feature_choices": [],
   "features": [
     {
       "name": "Primal Path",
+      "index": "primal-path",
       "url": "/api/features/primal-path"
     },
     {
       "name": "Frenzy",
+      "index": "frenzy",
       "url": "/api/features/frenzy"
     }
   ],
   "class": {
     "name": "Barbarian",
+    "index": "barbarian",
     "url": "/api/classes/barbarian"
   },
   "subclass": {
     "name": "Berserker",
+    "index": "berserker",
     "url": "/api/subclasses/berserker"
   },
   "url": "/api/subclasses/berserker/levels/3",
@@ -407,7 +431,7 @@
       <td align="left">feature_choices</td>
       <td align="left">A list of the available feature choices for a subclass</td>
       <td align="left">
-        list <a href="#namedapiresource">NamedAPIResource</a> (<a href="#features">Features</a>)
+        list <a href="#apireference">APIReference</a> (<a href="#features">Features</a>)
       </td>
     </tr>
 
@@ -415,7 +439,7 @@
       <td align="left">features</td>
       <td align="left">The feature available for a subclass</td>
       <td align="left">
-        list <a href="#namedapiresource">NamedAPIResource</a> (<a href="#features">Features</a>)
+        list <a href="#apireference">APIReference</a> (<a href="#features">Features</a>)
       </td>
     </tr>
 
@@ -423,7 +447,7 @@
       <td align="left">classes</td>
       <td align="left">The class that has access to subclass feature</td>
       <td align="left">
-        list <a href="#namedapiresource">NamedAPIResource</a> (<a href="#classes">Classes</a>)
+        list <a href="#apireference">APIReference</a> (<a href="#classes">Classes</a>)
       </td>
     </tr>
 
@@ -431,7 +455,7 @@
       <td align="left">subclass</td>
       <td align="left">The subclass name</td>
       <td align="left">
-        list <a href="#namedapiresource">NamedAPIResource</a> (<a href="#subclasses">Subclasses</a>)
+        list <a href="#apireference">APIReference</a> (<a href="#subclasses">Subclasses</a>)
       </td>
     </tr>
     <tr>
@@ -481,7 +505,7 @@
     <td align="left">results</td>
     <td align="left">A list of the available feature choices for a subclass at the requested level</td>
     <td align="left">
-      list <a href="#namedapiresource">NamedAPIResource</a> (<a href="#features">Features</a>)
+      list <a href="#apireference">APIReference</a> (<a href="#features">Features</a>)
     </td>
   </tr>
 </tbody>

--- a/src/views/partials/doc-resource-subraces.ejs
+++ b/src/views/partials/doc-resource-subraces.ejs
@@ -7,23 +7,26 @@
   "index": "hill-dwarf",
   "name": "Hill Dwarf",
   "race": {
+    "name": "Dwarf",
+    "index": "dwarf",
     "url": "/api/races/dwarf",
-    "name": "Dwarf"
   },
   "desc": "As a hill dwarf, you have keen senses, deep intuition, and remarkable resilience.",
   "ability_bonuses": [
     {
       "name": "WIS",
-      "url": "/api/ability-scores/wis",
-      "bonus": 1
+      "index": "wis",
+      "bonus": 1,
+      "url": "/api/ability-scores/wis"
     }
   ],
   "starting_proficiencies": [],
   "languages": [],
   "racial_traits": [
     {
-      "url": "/api/traits/stonecunning",
-      "name": "Dwarven Toughness"
+      "name": "Dwarven Toughness",
+      "index": "dwarven-toughness",
+      "url": "/api/traits/stonecunning"
     }
   ],
   "url": "/api/subraces/hill-dwarf"
@@ -54,7 +57,7 @@
       <td align="left">race</td>
       <td align="left">The parent race for this subrace.</td>
       <td align="left">
-        <a href="#namedapiresource">NamedAPIResource</a> (<a href="#races">Race</a>)
+        <a href="#apireference">APIReference</a> (<a href="#races">Race</a>)
       </td>
     </tr>
     <tr>
@@ -71,7 +74,7 @@
       <td align="left">starting_proficiencies</td>
       <td align="left">Starting proficiencies for all new characters of this subrace</td>
       <td align="left">
-        list <a href="#namedapiresource">NamedAPIResource</a> (<a href="#proficiencies"
+        list <a href="#apireference">APIReference</a> (<a href="#proficiencies"
           >Proficiencies</a
         >)
       </td>
@@ -80,7 +83,7 @@
       <td align="left">languages</td>
       <td align="left">Starting languages for all new characters of this subrace</td>
       <td align="left">
-        list <a href="#namedapiresource">NamedAPIResource</a> (<a href="#languages">Proficiencies</a
+        list <a href="#apireference">APIReference</a> (<a href="#languages">Proficiencies</a
         >)
       </td>
     </tr>
@@ -88,7 +91,7 @@
       <td align="left">traits</td>
       <td align="left">Racial traits that provide benefits to its members</td>
       <td align="left">
-        list <a href="#namedapiresource">NamedAPIResource</a> (<a href="#traits">Trait</a>)
+        list <a href="#apireference">APIReference</a> (<a href="#traits">Trait</a>)
       </td>
     </tr>
     <tr>
@@ -138,7 +141,7 @@
       <td align="left">results</td>
       <td align="left">Subracial traits that provide benefits to its members</td>
       <td align="left">
-        list <a href="#namedapiresource">NamedAPIResource</a> (<a href="#traits">Traits</a>)
+        list <a href="#apireference">APIReference</a> (<a href="#traits">Traits</a>)
       </td>
     </tr>
   </tbody>
@@ -182,7 +185,7 @@
     <td align="left">results</td>
     <td align="left">Subracial proficiences that provide benefits to its members</td>
     <td align="left">
-      list <a href="#namedapiresource">NamedAPIResource</a> (<a href="#proficiences">Proficiencies</a>)
+      list <a href="#apireference">APIReference</a> (<a href="#proficiences">Proficiencies</a>)
     </td>
   </tr></tbody>
 </table>

--- a/src/views/partials/doc-resource-traits.ejs
+++ b/src/views/partials/doc-resource-traits.ejs
@@ -8,12 +8,14 @@
   "races": [
     {
       "name": "Halfling",
+      "index": "halfling",
       "url": "/api/races/halfling"
     }
   ],
   "subraces": [
     {
       "name": "Lightfoot Halfling",
+      "index": "lightfoot-halfling",
       "url": "/api/subraces/lightfoot-halfling"
     }
   ],
@@ -44,7 +46,7 @@
       <td align="left">races</td>
       <td align="left">Races that have access to the trait</td>
       <td align="left">
-        list <a href="#namedapiresource">NamedAPIResource</a> (<a href="#proficiences"
+        list <a href="#apireference">APIReference</a> (<a href="#proficiences"
           >Proficiencies</a
         >)
       </td>
@@ -53,7 +55,7 @@
       <td align="left">subraces</td>
       <td align="left">Subraces that have access to the trait</td>
       <td align="left">
-        list <a href="#namedapiresource">NamedAPIResource</a> (<a href="#proficiences"
+        list <a href="#apireference">APIReference</a> (<a href="#proficiences"
           >Proficiencies</a
         >)
       </td>


### PR DESCRIPTION
## What does this do?
- Changes the name of the NamedAPIResource structure to APIReference, to better reflect the purpose of the structure.
- Brings the docs up to date with [this database PR enforcing consistent structure for internal references (#249)](https://github.com/bagelbits/5e-database/pull/249):
    - Updates example data to include *full* APIReference structures, by adding `index` attributes where they were lacking.
    - Swaps ClassAPIResource structures in the data for URL strings

Note: The ClassAPIResource structure definition remains, as it is still used in the Spellcasting resource list generated by the API. In future, this structure can be fully removed when Spellcasting is merged into Class documents.

## How was it tested?
Locally

## Is there a Github issue this is resolving?
No issue on this repo, but resolves the request from @bagelbits on [issue #243 in the database repo](https://github.com/bagelbits/5e-database/issues/243).

## Here's a fun image for your troubles
![image](https://user-images.githubusercontent.com/6972523/92325852-b945f200-f045-11ea-8087-c393538d52c9.png)

