### PR TITLE
Add `spells` attribute to Classes docs

### DIFF
--- a/src/views/partials/doc-resource-classes.ejs
+++ b/src/views/partials/doc-resource-classes.ejs
@@ -88,6 +88,7 @@
     }
   ],
   "spellcasting": "/api/spellcasting/warlock",
+  "spells": "/api/classes/warlock/spells",
   "url": "/api/classes/warlock"
 }</code></pre>
 
@@ -175,6 +176,16 @@
       </td>
       <td align="left">
         string (<a href="#spellcasting">Spellcasting</a>)
+      </td>
+    </tr>
+    <tr>
+      <td align="left">spells</td>
+      <td align="left">
+        The URL of the class's spell <a href="#resource-lists">Resource List</a>. Returns a list of
+        all spells that can be learned or cast by the class.
+      </td>
+      <td align="left">
+        string
       </td>
     </tr>
     <tr>


### PR DESCRIPTION
## What does this do?
Updates the documentation to include changes made by [this PR in the database repo](https://github.com/bagelbits/5e-database/pull/257), which adds a `spells` attribute to class documents, linking to the class spells Resource List endpoint in `/api/classes/{index}/spells`.

## How was it tested?
Locally

## Is there a Github issue this is resolving?
No, but complements [this PR in the database repo](https://github.com/bagelbits/5e-database/pull/257)

## Here's a fun image for your troubles
![image](https://user-images.githubusercontent.com/6972523/93015368-ce280580-f5b0-11ea-90b3-27029c4c4dc5.png)

