### PR TITLE
Filter class features by the name query parameter

### DIFF
--- a/src/controllers/api/featureController.js
+++ b/src/controllers/api/featureController.js
@@ -2,7 +2,12 @@ const Feature = require('../../models/feature');
 const utility = require('./utility');
 
 exports.index = async (req, res, next) => {
-  await Feature.find()
+  const search_queries = {};
+  if (req.query.name !== undefined) {
+    search_queries.name = { $regex: new RegExp(utility.escapeRegExp(req.query.name), 'i') };
+  }
+
+  await Feature.find(search_queries)
     .sort({ index: 'asc' })
     .then(data => {
       res.status(200).json(utility.NamedAPIResource(data));

--- a/src/tests/integration/server.itest.js
+++ b/src/tests/integration/server.itest.js
@@ -392,6 +392,24 @@ describe('/api/features', () => {
     expect(res.statusCode).toEqual(200);
     expect(res.body.results.length).not.toEqual(0);
   });
+  describe('with name query', () => {
+    it('returns the named object', async () => {
+      const indexRes = await request(app).get('/api/features');
+      const name = indexRes.body.results[1].name;
+      const res = await request(app).get(`/api/features?name=${name}`);
+      expect(res.statusCode).toEqual(200);
+      expect(res.body.results[0].name).toEqual(name);
+    });
+
+    it('is case insensitive', async () => {
+      const indexRes = await request(app).get('/api/features');
+      const name = indexRes.body.results[1].name;
+      const queryName = name.toLowerCase();
+      const res = await request(app).get(`/api/features?name=${queryName}`);
+      expect(res.statusCode).toEqual(200);
+      expect(res.body.results[0].name).toEqual(name);
+    });
+  });
   describe('/api/features/:index', () => {
     it('should return one object', async () => {
       const indexRes = await request(app).get('/api/features');


### PR DESCRIPTION
## What does this do?
This PR adds the `name` query parameter to the `/features` endpoint, so you can filter class features by their name.

## How was it tested?
Manually, as well as with the automated tests. I added tests to `server.itest.js` that test this endpoint with the parameter. Please let me know if more tests would be appropriate!

## Is there a Github issue this is resolving?
No, not that I know of.

## Here's a fun image for your troubles
![An adorable dog in a cute sweater stares up at the camera](https://unsplash.com/photos/Mv9hjnEUHR4/download?force=true&w=640)
