### PR TITLE
Spell level query

### DIFF
--- a/src/controllers/api/spellController.js
+++ b/src/controllers/api/spellController.js
@@ -10,6 +10,10 @@ exports.index = async (req, res, next) => {
     search_queries.name = { $regex: new RegExp(utility.escapeRegExp(req.query.name), 'i') };
   }
 
+  if (req.query.levels !== undefined) {
+    search_queries.level = { $in: req.query.level.split(",") };
+  }
+
   const redisKey = req.originalUrl;
   const data = await getAsync(redisKey).catch(_err => {
     return;

--- a/src/controllers/api/spellController.js
+++ b/src/controllers/api/spellController.js
@@ -11,7 +11,7 @@ exports.index = async (req, res, next) => {
   }
 
   if (req.query.levels !== undefined) {
-    search_queries.level = { $in: req.query.level.split(",") };
+    search_queries.level = { $in: req.query.level.split(',') };
   }
 
   const redisKey = req.originalUrl;

--- a/src/controllers/api/spellController.js
+++ b/src/controllers/api/spellController.js
@@ -10,8 +10,8 @@ exports.index = async (req, res, next) => {
     search_queries.name = { $regex: new RegExp(utility.escapeRegExp(req.query.name), 'i') };
   }
 
-  if (req.query.levels !== undefined) {
-    search_queries.level = { $in: req.query.levels.split(',') };
+  if (req.query.level !== undefined) {
+    search_queries.level = { $in: req.query.level.split(',') };
   }
 
   const redisKey = req.originalUrl;

--- a/src/controllers/api/spellController.js
+++ b/src/controllers/api/spellController.js
@@ -11,7 +11,7 @@ exports.index = async (req, res, next) => {
   }
 
   if (req.query.levels !== undefined) {
-    search_queries.level = { $in: req.query.level.split(',') };
+    search_queries.level = { $in: req.query.levels.split(',') };
   }
 
   const redisKey = req.originalUrl;

--- a/src/models/spell.js
+++ b/src/models/spell.js
@@ -8,6 +8,7 @@ var SpellSchema = new Schema({
   },
   index: String,
   name: String,
+  level: Number,
   url: String
 });
 

--- a/src/tests/integration/server.itest.js
+++ b/src/tests/integration/server.itest.js
@@ -586,7 +586,7 @@ describe('/api/monsters', () => {
   describe('with challenge_rating query', () => {
     describe('with only one provided challenge rating', () => {
       it('returns expected objects', async () => {
-        const expectedCR = 0.25
+        const expectedCR = 0.25;
         const res = await request(app).get(`/api/monsters?challenge_rating=${expectedCR}`);
         expect(res.statusCode).toEqual(200);
 
@@ -623,7 +623,7 @@ describe('/api/monsters', () => {
         ).toBeTruthy();
       });
     });
-  })
+  });
 
   describe('/api/monsters/:index', () => {
     it('should return one object', async () => {
@@ -883,7 +883,9 @@ describe('/api/spells', () => {
         const level8Res = await request(app).get(`/api/spells?levels=${expectLevel2}`);
         expect(level8Res.statusCode).toEqual(200);
 
-        const bothRes = await request(app).get(`/api/spells?levels=${expectedLevel1},${expectLevel2}`);
+        const bothRes = await request(app).get(
+          `/api/spells?levels=${expectedLevel1},${expectLevel2}`
+        );
         expect(bothRes.statusCode).toEqual(200);
         expect(bothRes.body.count).toEqual(level1Res.body.count + level8Res.body.count);
 
@@ -897,7 +899,7 @@ describe('/api/spells', () => {
         ).toBeTruthy();
       });
     });
-  })
+  });
 
   describe('/api/spells/:index', () => {
     it('should return one object', async () => {

--- a/src/tests/integration/server.itest.js
+++ b/src/tests/integration/server.itest.js
@@ -857,7 +857,7 @@ describe('/api/spells', () => {
     });
   });
 
-  describe('with levels query', () => {
+  describe('with level query', () => {
     describe('with only one provided level', () => {
       it('returns expected objects', async () => {
         const expectedLevel = 2;
@@ -873,18 +873,18 @@ describe('/api/spells', () => {
       });
     });
 
-    describe('with many provided levels', () => {
+    describe('with many provided level', () => {
       it('returns expected objects', async () => {
         const expectedLevel1 = 1;
-        const level1Res = await request(app).get(`/api/spells?levels=${expectedLevel1}`);
+        const level1Res = await request(app).get(`/api/spells?level=${expectedLevel1}`);
         expect(level1Res.statusCode).toEqual(200);
 
         const expectLevel2 = 8;
-        const level8Res = await request(app).get(`/api/spells?levels=${expectLevel2}`);
+        const level8Res = await request(app).get(`/api/spells?level=${expectLevel2}`);
         expect(level8Res.statusCode).toEqual(200);
 
         const bothRes = await request(app).get(
-          `/api/spells?levels=${expectedLevel1},${expectLevel2}`
+          `/api/spells?level=${expectedLevel1},${expectLevel2}`
         );
         expect(bothRes.statusCode).toEqual(200);
         expect(bothRes.body.count).toEqual(level1Res.body.count + level8Res.body.count);

--- a/src/tests/integration/server.itest.js
+++ b/src/tests/integration/server.itest.js
@@ -583,42 +583,47 @@ describe('/api/monsters', () => {
     });
   });
 
-  describe('with only one provided challenge rating query', () => {
-    it('returns expected objects', async () => {
-      const res = await request(app).get('/api/monsters?challenge_rating=0.25');
-      expect(res.statusCode).toEqual(200);
+  describe('with challenge_rating query', () => {
+    describe('with only one provided challenge rating', () => {
+      it('returns expected objects', async () => {
+        const expectedCR = 0.25
+        const res = await request(app).get(`/api/monsters?challenge_rating=${expectedCR}`);
+        expect(res.statusCode).toEqual(200);
 
-      const randomIndex = Math.floor(Math.random() * res.body.results.length);
-      const randomResult = res.body.results[randomIndex];
+        const randomIndex = Math.floor(Math.random() * res.body.results.length);
+        const randomResult = res.body.results[randomIndex];
 
-      const indexRes = await request(app).get(`/api/monsters/${randomResult.index}`);
-      expect(indexRes.statusCode).toEqual(200);
-      expect(indexRes.body.challenge_rating).toEqual(0.25);
+        const indexRes = await request(app).get(`/api/monsters/${randomResult.index}`);
+        expect(indexRes.statusCode).toEqual(200);
+        expect(indexRes.body.challenge_rating).toEqual(expectedCR);
+      });
     });
-  });
 
-  describe('with many provided challenge ratings query', () => {
-    it('returns expected objects', async () => {
-      const cr1Res = await request(app).get('/api/monsters?challenge_rating=1');
-      expect(cr1Res.statusCode).toEqual(200);
+    describe('with many provided challenge ratings', () => {
+      it('returns expected objects', async () => {
+        const cr1 = 1;
+        const cr1Res = await request(app).get(`/api/monsters?challenge_rating=${cr1}`);
+        expect(cr1Res.statusCode).toEqual(200);
 
-      const cr20Res = await request(app).get('/api/monsters?challenge_rating=20');
-      expect(cr20Res.statusCode).toEqual(200);
+        const cr20 = 20;
+        const cr20Res = await request(app).get(`/api/monsters?challenge_rating=${cr20}`);
+        expect(cr20Res.statusCode).toEqual(200);
 
-      const bothRes = await request(app).get('/api/monsters?challenge_rating=1,20');
-      expect(bothRes.statusCode).toEqual(200);
-      expect(bothRes.body.count).toEqual(cr1Res.body.count + cr20Res.body.count);
+        const bothRes = await request(app).get(`/api/monsters?challenge_rating=${cr1},${cr20}`);
+        expect(bothRes.statusCode).toEqual(200);
+        expect(bothRes.body.count).toEqual(cr1Res.body.count + cr20Res.body.count);
 
-      const randomIndex = Math.floor(Math.random() * bothRes.body.results.length);
-      const randomResult = bothRes.body.results[randomIndex];
+        const randomIndex = Math.floor(Math.random() * bothRes.body.results.length);
+        const randomResult = bothRes.body.results[randomIndex];
 
-      const indexRes = await request(app).get(`/api/monsters/${randomResult.index}`);
-      expect(indexRes.statusCode).toEqual(200);
-      expect(
-        indexRes.body.challenge_rating == 1 || indexRes.body.challenge_rating == 20
-      ).toBeTruthy();
+        const indexRes = await request(app).get(`/api/monsters/${randomResult.index}`);
+        expect(indexRes.statusCode).toEqual(200);
+        expect(
+          indexRes.body.challenge_rating == cr1 || indexRes.body.challenge_rating == cr20
+        ).toBeTruthy();
+      });
     });
-  });
+  })
 
   describe('/api/monsters/:index', () => {
     it('should return one object', async () => {
@@ -851,6 +856,49 @@ describe('/api/spells', () => {
       expect(res.body.results[0].name).toEqual(name);
     });
   });
+
+  describe('with levels query', () => {
+    describe('with only one provided level', () => {
+      it('returns expected objects', async () => {
+        const expectedLevel = 2;
+        const res = await request(app).get(`/api/spells?level=${expectedLevel}`);
+        expect(res.statusCode).toEqual(200);
+
+        const randomIndex = Math.floor(Math.random() * res.body.results.length);
+        const randomResult = res.body.results[randomIndex];
+
+        const indexRes = await request(app).get(`/api/spells/${randomResult.index}`);
+        expect(indexRes.statusCode).toEqual(200);
+        expect(indexRes.body.level).toEqual(expectedLevel);
+      });
+    });
+
+    describe('with many provided levels', () => {
+      it('returns expected objects', async () => {
+        const expectedLevel1 = 1;
+        const level1Res = await request(app).get(`/api/spells?levels=${expectedLevel1}`);
+        expect(level1Res.statusCode).toEqual(200);
+
+        const expectLevel2 = 8;
+        const level8Res = await request(app).get(`/api/spells?levels=${expectLevel2}`);
+        expect(level8Res.statusCode).toEqual(200);
+
+        const bothRes = await request(app).get(`/api/spells?levels=${expectedLevel1},${expectLevel2}`);
+        expect(bothRes.statusCode).toEqual(200);
+        expect(bothRes.body.count).toEqual(level1Res.body.count + level8Res.body.count);
+
+        const randomIndex = Math.floor(Math.random() * bothRes.body.results.length);
+        const randomResult = bothRes.body.results[randomIndex];
+
+        const indexRes = await request(app).get(`/api/spells/${randomResult.index}`);
+        expect(indexRes.statusCode).toEqual(200);
+        expect(
+          indexRes.body.level == expectedLevel1 || indexRes.body.level == expectLevel2
+        ).toBeTruthy();
+      });
+    });
+  })
+
   describe('/api/spells/:index', () => {
     it('should return one object', async () => {
       const indexRes = await request(app).get('/api/spells');

--- a/src/views/partials/doc-resource-spells.ejs
+++ b/src/views/partials/doc-resource-spells.ejs
@@ -73,6 +73,31 @@
   "url": "/api/spells/acid-arrow"
 }</code></pre>
 
+<h4>GET params</h4>
+
+<table>
+  <thead>
+    <tr>
+      <th align="left">Name</th>
+      <th align="left">Description</th>
+      <th align="left">Examples</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td align="left">levels</td>
+      <td align="left">Lets you filter spells for specific levels. It returns a list with all the spells which have this
+        level or an empty list if none can be found. Multiple ratings are supported.
+      </td>
+      <td align="left">
+        <code>/spells?levels=2</code>
+        <code>/spells?levels=0.25</code>
+        <code>/spells?levels=2,0.25,4</code>
+      </td>
+    </tr>
+  </tbody>
+</table>
+
 <h4>Spell</h4>
 
 <table>
@@ -109,7 +134,8 @@
 
     <tr>
       <td align="left">components</td>
-      <td align="left">The required components for a spell are shorthanded to V,S, and M which stand for verbal, somatic, and material</td>
+      <td align="left">The required components for a spell are shorthanded to V,S, and M which stand for verbal,
+        somatic, and material</td>
       <td align="left">list</td>
     </tr>
 

--- a/src/views/partials/doc-resource-spells.ejs
+++ b/src/views/partials/doc-resource-spells.ejs
@@ -85,14 +85,13 @@
   </thead>
   <tbody>
     <tr>
-      <td align="left">levels</td>
+      <td align="left">level</td>
       <td align="left">Lets you filter spells for specific levels. It returns a list with all the spells which have this
         level or an empty list if none can be found. Multiple ratings are supported.
       </td>
       <td align="left">
-        <code>/spells?levels=2</code>
-        <code>/spells?levels=0.25</code>
-        <code>/spells?levels=2,0.25,4</code>
+        <code>/spells?level=2</code>
+        <code>/spells?level=2,4</code>
       </td>
     </tr>
   </tbody>


### PR DESCRIPTION
## What does this do?
Exposes a `levels` query param for the spells endpoint.

## How was it tested?
CI and added tests.

## Is there a Github issue this is resolving?
This is part of #105

## Here's a fun image for your troubles
![image](https://user-images.githubusercontent.com/353626/94958441-61fc3b80-04a4-11eb-8713-f5ac32a68945.png)
