### PR TITLE
Documentation: Remove 'list' from ApiReferences that are not lists

### DIFF
--- a/src/views/partials/doc-resource-equipment.ejs
+++ b/src/views/partials/doc-resource-equipment.ejs
@@ -75,7 +75,7 @@
       <td align="left">equipment_category</td>
       <td align="left">The category of equipment this falls into</td>
       <td align="left">
-        list <a href="#apireference">APIReference</a> (<a href="#equipment-categories"
+        <a href="#apireference">APIReference</a> (<a href="#equipment-categories"
           >Equipment Categories</a
         >)
       </td>
@@ -185,7 +185,7 @@
       <td align="left">equipment_category</td>
       <td align="left">The category of equipment this falls into</td>
       <td align="left">
-        list <a href="#apireference">APIReference</a> (<a href="#equipment-categories"
+        <a href="#apireference">APIReference</a> (<a href="#equipment-categories"
           >Equipment Categories</a
         >)
       </td>
@@ -193,7 +193,7 @@
     <tr>
       <td align="left">armor_category</td>
       <td align="left">The category of armor this falls into</td>
-      <td align="left">list string</td>
+      <td align="left">string</td>
     </tr>
     <tr>
       <td align="left">armor_class</td>
@@ -276,7 +276,7 @@
       <td align="left">equipment_category</td>
       <td align="left">The category of equipment this falls into</td>
       <td align="left">
-        list <a href="#apireference">APIReference</a> (<a href="#equipment-categories"
+        <a href="#apireference">APIReference</a> (<a href="#equipment-categories"
           >Equipment Categories</a
         >)
       </td>
@@ -285,7 +285,7 @@
       <td align="left">gear_category</td>
       <td align="left">The category of adventuring gear this falls into</td>
       <td align="left">
-        list <a href="#apireference">APIReference</a> (<a href="#equipment-categories"
+        <a href="#apireference">APIReference</a> (<a href="#equipment-categories"
           >Equipment Categories</a
         >)
       </td>
@@ -453,7 +453,7 @@
       <td align="left">equipment_category</td>
       <td align="left">The category of equipment this falls into</td>
       <td align="left">
-        list <a href="#apireference">APIReference</a> (<a href="#equipment-categories"
+        <a href="#apireference">APIReference</a> (<a href="#equipment-categories"
           >Equipment Categories</a
         >)
       </td>
@@ -462,7 +462,7 @@
       <td align="left">gear_category</td>
       <td align="left">The category of adventuring gear this falls into</td>
       <td align="left">
-        list <a href="#apireference">APIReference</a> (<a href="#equipment-categories"
+        <a href="#apireference">APIReference</a> (<a href="#equipment-categories"
           >Equipment Categories</a
         >)
       </td>

--- a/src/views/partials/doc-resource-magic-items.ejs
+++ b/src/views/partials/doc-resource-magic-items.ejs
@@ -43,7 +43,7 @@
     <tr>
       <td align="left">equipment_category</td>
       <td align="left">The associated Equipment Category for this magic item.</td>
-      <td align="left">list
+      <td align="left">
         <a href="#apireference">APIReference</a> (<a href="#equipment-categories">Equipment Categories</a>)
       </td>
     </tr>

--- a/src/views/partials/doc-resource-skills.ejs
+++ b/src/views/partials/doc-resource-skills.ejs
@@ -51,7 +51,7 @@
       <td align="left">ability_score</td>
       <td align="left">The ability score associated with this skill.</td>
       <td align="left">
-        list <a href="#apireference">APIReference</a> (<a href="#ability-scores"
+        <a href="#apireference">APIReference</a> (<a href="#ability-scores"
           >Ability Score</a
         >)
       </td>

--- a/src/views/partials/doc-resource-subclasses.ejs
+++ b/src/views/partials/doc-resource-subclasses.ejs
@@ -351,10 +351,10 @@
     </tr>
 
     <tr>
-      <td align="left">classes</td>
+      <td align="left">class</td>
       <td align="left">The class that has access to subclass feature</td>
       <td align="left">
-        list <a href="#apireference">APIReference</a> (<a href="#classes">Classes</a>)
+        <a href="#apireference">APIReference</a> (<a href="#classes">Classes</a>)
       </td>
     </tr>
 
@@ -362,7 +362,7 @@
       <td align="left">subclass</td>
       <td align="left">The subclass name</td>
       <td align="left">
-        list <a href="#apireference">APIReference</a> (<a href="#subclasses">Subclasses</a>)
+        <a href="#apireference">APIReference</a> (<a href="#subclasses">Subclasses</a>)
       </td>
     </tr>
     <tr>
@@ -444,18 +444,18 @@
     </tr>
 
     <tr>
-      <td align="left">classes</td>
+      <td align="left">classe</td>
       <td align="left">The class that has access to subclass feature</td>
       <td align="left">
-        list <a href="#apireference">APIReference</a> (<a href="#classes">Classes</a>)
+        <a href="#apireference">APIReference</a> (<a href="#classes">Classes</a>)
       </td>
     </tr>
 
-    tr>
+    <tr>
       <td align="left">subclass</td>
       <td align="left">The subclass name</td>
       <td align="left">
-        list <a href="#apireference">APIReference</a> (<a href="#subclasses">Subclasses</a>)
+        <a href="#apireference">APIReference</a> (<a href="#subclasses">Subclasses</a>)
       </td>
     </tr>
     <tr>

--- a/src/views/partials/doc-resource-subclasses.ejs
+++ b/src/views/partials/doc-resource-subclasses.ejs
@@ -358,7 +358,7 @@
       </td>
     </tr>
 
-    tr>
+    <tr>
       <td align="left">subclass</td>
       <td align="left">The subclass name</td>
       <td align="left">


### PR DESCRIPTION
## What does this do?
The documentation incorrectly shows some properties as 'list ApiReference', when they are just ApiReferences. This fixes it

## How was it tested?
lgtm visually

## Is there a Github issue this is resolving?
No

