### PR TITLE
ecs: small documentation improvements

### DIFF
--- a/src/views/partials/doc-resource-ability-scores.ejs
+++ b/src/views/partials/doc-resource-ability-scores.ejs
@@ -38,34 +38,34 @@
   <tbody>
     <tr>
       <td align="left">index</td>
-      <td align="left">The ability score index for shorthand searching</td>
+      <td align="left">The ability score index for shorthand searching.</td>
       <td align="left">string</td>
     </tr>
     <tr>
       <td align="left">name</td>
-      <td align="left">The abbreviated name for this ability score</td>
+      <td align="left">The abbreviated name for this ability score.</td>
       <td align="left">string</td>
     </tr>
     <tr>
       <td align="left">full_name</td>
-      <td align="left">The full name for this ability score</td>
+      <td align="left">The full name for this ability score.</td>
       <td align="left">string</td>
     </tr>
     <tr>
       <td align="left">desc</td>
-      <td align="left">A brief description of this ability score and its uses</td>
+      <td align="left">A brief description of this ability score and its uses.</td>
       <td align="left">list string</td>
     </tr>
     <tr>
       <td align="left">skills</td>
-      <td align="left">A list of skills that use this ability score</td>
+      <td align="left">A list of skills that use this ability score.</td>
       <td align="left">
         list <a href="#apireference">APIReference</a> (<a href="#skills">Skills</a>)
       </td>
     </tr>
     <tr>
       <td align="left">url</td>
-      <td align="left">The URL of the referenced resource</td>
+      <td align="left">The URL of the referenced resource.</td>
       <td align="left">string</td>
     </tr>
   </tbody>

--- a/src/views/partials/doc-resource-ability-scores.ejs
+++ b/src/views/partials/doc-resource-ability-scores.ejs
@@ -48,17 +48,17 @@
     </tr>
     <tr>
       <td align="left">full_name</td>
-      <td align="left">The full name for this ability scores</td>
+      <td align="left">The full name for this ability score</td>
       <td align="left">string</td>
     </tr>
     <tr>
       <td align="left">desc</td>
-      <td align="left">A brief description on this ability score and its uses</td>
+      <td align="left">A brief description of this ability score and its uses</td>
       <td align="left">list string</td>
     </tr>
     <tr>
       <td align="left">skills</td>
-      <td align="left">A list of skills that uses this ability score</td>
+      <td align="left">A list of skills that use this ability score</td>
       <td align="left">
         list <a href="#apireference">APIReference</a> (<a href="#skills">Skills</a>)
       </td>

--- a/src/views/partials/doc-resource-classes.ejs
+++ b/src/views/partials/doc-resource-classes.ejs
@@ -109,12 +109,12 @@
     </tr>
     <tr>
       <td align="left">name</td>
-      <td align="left">The name for this class resource</td>
+      <td align="left">The name for this class resource.</td>
       <td align="left">string</td>
     </tr>
     <tr>
       <td align="left">hit_die</td>
-      <td align="left">The hit die of the class. (ex: 12 == 1d12)</td>
+      <td align="left">The hit die of the class. (ex: 12 == 1d12).</td>
       <td align="left">integer</td>
     </tr>
     <tr>
@@ -138,7 +138,7 @@
     </tr>
     <tr>
       <td align="left">saving_throws</td>
-      <td align="left">Saving throws that the class is proficient in</td>
+      <td align="left">Saving throws that the class is proficient in.</td>
       <td align="left">
         list <a href="#apireference">APIReference</a> (<a href="#ability-scores"
           >Ability Scores</a
@@ -220,12 +220,12 @@
     </tr>
     <tr>
       <td align="left">count</td>
-      <td align="left">The number of subclasses available to a class</td>
+      <td align="left">The number of subclasses available to a class.</td>
       <td align="left">integer</td>
     </tr>
     <tr>
       <td align="left">results</td>
-      <td align="left">A list of subclasses available to a class</td>
+      <td align="left">A list of subclasses available to a class.</td>
       <td align="left">
         list <a href="#apireference">APIReference</a> (<a href="#subclass">Subclass</a>)
       </td>
@@ -266,12 +266,12 @@
   <tbody>
     <tr>
       <td align="left">count</td>
-      <td align="left">The number of spells available to a class</td>
+      <td align="left">The number of spells available to a class.</td>
       <td align="left">integer</td>
     </tr>
     <tr>
       <td align="left">results</td>
-      <td align="left">A list of the spells available to a class</td>
+      <td align="left">A list of the spells available to a class.</td>
       <td align="left">
         list <a href="#apireference">APIReference</a> (<a href="#spells">Spells</a>)
       </td>
@@ -312,12 +312,12 @@
     <tbody>
       <tr>
         <td align="left">count</td>
-        <td align="left">The number of features available to a class</td>
+        <td align="left">The number of features available to a class.</td>
         <td align="left">integer</td>
       </tr>
       <tr>
         <td align="left">results</td>
-        <td align="left">A list of features available to a class</td>
+        <td align="left">A list of features available to a class.</td>
         <td align="left">
           list <a href="#apireference">APIReference</a> (<a href="#features">Features</a>)
         </td>
@@ -359,12 +359,12 @@
     <tbody>
       <tr>
         <td align="left">count</td>
-        <td align="left">The number of proficiencies available to a class</td>
+        <td align="left">The number of proficiencies available to a class.</td>
         <td align="left">integer</td>
       </tr>
       <tr>
         <td align="left">results</td>
-        <td align="left">A list of proficiencies available to a class</td>
+        <td align="left">A list of proficiencies available to a class.</td>
         <td align="left">
           list <a href="#apireference">APIReference</a> (<a href="#proficiencies">Proficiencies</a>)
         </td>
@@ -699,12 +699,12 @@
     <tbody>
       <tr>
         <td align="left">count</td>
-        <td align="left">The number of features available to a class at the requested level</td>
+        <td align="left">The number of features available to a class at the requested level.</td>
         <td align="left">integer</td>
       </tr>
       <tr>
         <td align="left">results</td>
-        <td align="left">A list of features available to a class at the requested level</td>
+        <td align="left">A list of features available to a class at the requested level.</td>
         <td align="left">
           list <a href="#apireference">APIReference</a> (<a href="#features">Features</a>)
         </td>
@@ -745,12 +745,12 @@
     <tbody>
       <tr>
         <td align="left">count</td>
-        <td align="left">The number of spells available to a class at the specified level</td>
+        <td align="left">The number of spells available to a class at the specified level.</td>
         <td align="left">integer</td>
       </tr>
       <tr>
         <td align="left">results</td>
-        <td align="left">A list of spells availabe to a class at the specified level</td>
+        <td align="left">A list of spells availabe to a class at the specified level.</td>
         <td align="left">
           list <a href="#apireference">APIReference</a> (<a href="#spells">Spells</a>)
         </td>

--- a/src/views/partials/doc-resource-common-models.ejs
+++ b/src/views/partials/doc-resource-common-models.ejs
@@ -17,12 +17,12 @@
     </tr>
     <tr>
       <td align="left">name</td>
-      <td align="left">The name of the referenced resource</td>
+      <td align="left">The name of the referenced resource.</td>
       <td align="left">string</td>
     </tr>
     <tr>
       <td align="left">url</td>
-      <td align="left">The URL of the referenced resource</td>
+      <td align="left">The URL of the referenced resource.</td>
       <td align="left">string</td>
     </tr>
   </tbody>
@@ -45,12 +45,12 @@
     </tr>
     <tr>
       <td align="left">class</td>
-      <td align="left">The class of whom the resource belongs to</td>
+      <td align="left">The class of whom the resource belongs to.</td>
       <td align="left">string</td>
     </tr>
     <tr>
       <td align="left">url</td>
-      <td align="left">The URL of the referenced resource</td>
+      <td align="left">The URL of the referenced resource.</td>
       <td align="left">string</td>
     </tr>
   </tbody>
@@ -68,17 +68,17 @@
   <tbody>
     <tr>
       <td align="left">choose</td>
-      <td align="left">The number of items to pick from the list</td>
+      <td align="left">The number of items to pick from the list.</td>
       <td align="left">integer</td>
     </tr>
     <tr>
       <td align="left">type</td>
-      <td align="left">The type of the resources to choose from</td>
+      <td align="left">The type of the resources to choose from.</td>
       <td align="left">string</td>
     </tr>
     <tr>
       <td align="left">from</td>
-      <td align="left">A list of resources to choose from</td>
+      <td align="left">A list of resources to choose from.</td>
       <td align="left">list <a href="#apireference">APIReference</a></td>
     </tr>
   </tbody>
@@ -97,12 +97,12 @@
   <tbody>
     <tr>
       <td align="left">quantity</td>
-      <td align="left">The numerical amount of coins</td>
+      <td align="left">The numerical amount of coins.</td>
       <td align="left">integer</td>
     </tr>
     <tr>
       <td align="left">unit</td>
-      <td align="left">The unit of coinage</td>
+      <td align="left">The unit of coinage.</td>
       <td align="left">string</td>
     </tr>
   </tbody>

--- a/src/views/partials/doc-resource-conditions.ejs
+++ b/src/views/partials/doc-resource-conditions.ejs
@@ -30,22 +30,22 @@
   <tbody>
     <tr>
       <td align="left">index</td>
-      <td align="left">The condition index for shorthand searching</td>
+      <td align="left">The condition index for shorthand searching.</td>
       <td align="left">string</td>
     </tr>
     <tr>
       <td align="left">name</td>
-      <td align="left">The name for this condition resource</td>
+      <td align="left">The name for this condition resource.</td>
       <td align="left">string</td>
     </tr>
     <tr>
       <td align="left">desc</td>
-      <td align="left">A brief description of the condition</td>
+      <td align="left">A brief description of the condition.</td>
       <td align="left">list string</td>
     </tr>
     <tr>
       <td align="left">url</td>
-      <td align="left">The URL of the referenced resource</td>
+      <td align="left">The URL of the referenced resource.</td>
       <td align="left">string</td>
     </tr>
   </tbody>

--- a/src/views/partials/doc-resource-damage-types.ejs
+++ b/src/views/partials/doc-resource-damage-types.ejs
@@ -29,22 +29,22 @@
   <tbody>
     <tr>
       <td align="left">index</td>
-      <td align="left">The damage type index for shorthand searching</td>
+      <td align="left">The damage type index for shorthand searching.</td>
       <td align="left">string</td>
     </tr>
     <tr>
       <td align="left">name</td>
-      <td align="left">The name for this damage type resource</td>
+      <td align="left">The name for this damage type resource.</td>
       <td align="left">string</td>
     </tr>
     <tr>
       <td align="left">desc</td>
-      <td align="left">A brief description of the damage type</td>
+      <td align="left">A brief description of the damage type.</td>
       <td align="left">list string</td>
     </tr>
     <tr>
       <td align="left">url</td>
-      <td align="left">The URL of the referenced resource</td>
+      <td align="left">The URL of the referenced resource.</td>
       <td align="left">string</td>
     </tr>
   </tbody>

--- a/src/views/partials/doc-resource-equipment-categories.ejs
+++ b/src/views/partials/doc-resource-equipment-categories.ejs
@@ -37,19 +37,19 @@
   <tbody>
     <tr>
       <td align="left">index</td>
-      <td align="left">The equipment category index for shorthand searching</td>
+      <td align="left">The equipment category index for shorthand searching.</td>
       <td align="left">string</td>
     </tr>
 
     <tr>
       <td align="left">name</td>
-      <td align="left">The name of the equipment category</td>
+      <td align="left">The name of the equipment category.</td>
       <td align="left">string</td>
     </tr>
 
     <tr>
       <td align="left">equipment</td>
-      <td align="left">A list of the equipment that falls into this category</td>
+      <td align="left">A list of the equipment that falls into this category.</td>
       <td align="left">list
         <a href="#apireference">APIReference</a> (<a href="#equipment">Equipment</a>)
       </td>

--- a/src/views/partials/doc-resource-equipment.ejs
+++ b/src/views/partials/doc-resource-equipment.ejs
@@ -63,17 +63,17 @@
   <tbody>
     <tr>
       <td align="left">index</td>
-      <td align="left">The damage type index for shorthand searching</td>
+      <td align="left">The damage type index for shorthand searching.</td>
       <td align="left">string</td>
     </tr>
     <tr>
       <td align="left">name</td>
-      <td align="left">The name for this equipment resource</td>
+      <td align="left">The name for this equipment resource.</td>
       <td align="left">string</td>
     </tr>
     <tr>
       <td align="left">equipment_category</td>
-      <td align="left">The category of equipment this falls into</td>
+      <td align="left">The category of equipment this falls into.</td>
       <td align="left">
         <a href="#apireference">APIReference</a> (<a href="#equipment-categories"
           >Equipment Categories</a
@@ -82,27 +82,27 @@
     </tr>
     <tr>
       <td align="left">weapon_category</td>
-      <td align="left">The category of weapon this falls into</td>
+      <td align="left">The category of weapon this falls into.</td>
       <td align="left">string</td>
     </tr>
     <tr>
       <td align="left">weapon_range</td>
-      <td align="left">Whether this is a Melee or Ranged weapon</td>
+      <td align="left">Whether this is a Melee or Ranged weapon.</td>
       <td align="left">string</td>
     </tr>
     <tr>
       <td align="left">category_range</td>
-      <td align="left">A combination of weapon_category and weapon_range</td>
+      <td align="left">A combination of weapon_category and weapon_range.</td>
       <td align="left">string</td>
     </tr>
     <tr>
       <td align="left">cost</td>
-      <td align="left">The cost of the equipment</td>
+      <td align="left">The cost of the equipment.</td>
       <td align="left"><a href="#cost">Cost</a></td>
     </tr>
     <tr>
       <td align="left">damage</td>
-      <td align="left">Includes data on dice, bonus, and damage type</td>
+      <td align="left">Includes data on dice, bonus, and damage type.</td>
       <td align="left">map</td>
     </tr>
     <tr>
@@ -114,12 +114,12 @@
     </tr>
     <tr>
       <td align="left">weight</td>
-      <td align="left">How much the equipment weighs</td>
+      <td align="left">How much the equipment weighs.</td>
       <td align="left">integer</td>
     </tr>
     <tr>
       <td align="left">properties</td>
-      <td align="left">A list of the properties this weapon has</td>
+      <td align="left">A list of the properties this weapon has.</td>
       <td align="left">
         list <a href="#apireference">APIReference</a> (<a href="#weapon-properties"
           >Weapon Properties</a
@@ -128,7 +128,7 @@
     </tr>
     <tr>
       <td align="left">url</td>
-      <td align="left">The URL of the referenced resource</td>
+      <td align="left">The URL of the referenced resource.</td>
       <td align="left">string</td>
     </tr>
   </tbody>
@@ -173,17 +173,17 @@
   <tbody>
     <tr>
       <td align="left">index</td>
-      <td align="left">The damage type index for shorthand searching</td>
+      <td align="left">The damage type index for shorthand searching.</td>
       <td align="left">string</td>
     </tr>
     <tr>
       <td align="left">name</td>
-      <td align="left">The name for this equipment resource</td>
+      <td align="left">The name for this equipment resource.</td>
       <td align="left">string</td>
     </tr>
     <tr>
       <td align="left">equipment_category</td>
-      <td align="left">The category of equipment this falls into</td>
+      <td align="left">The category of equipment this falls into.</td>
       <td align="left">
         <a href="#apireference">APIReference</a> (<a href="#equipment-categories"
           >Equipment Categories</a
@@ -192,37 +192,37 @@
     </tr>
     <tr>
       <td align="left">armor_category</td>
-      <td align="left">The category of armor this falls into</td>
+      <td align="left">The category of armor this falls into.</td>
       <td align="left">string</td>
     </tr>
     <tr>
       <td align="left">armor_class</td>
-      <td align="left">Details on how to calculate armor class</td>
+      <td align="left">Details on how to calculate armor class.</td>
       <td align="left">map</td>
     </tr>
     <tr>
       <td align="left">str_minimum</td>
-      <td align="left">Minimum STR required to use this armor</td>
+      <td align="left">Minimum STR required to use this armor.</td>
       <td align="left">integer</td>
     </tr>
     <tr>
       <td align="left">stealth_disadvantage</td>
-      <td align="left">Whether the armor gives disadvantage for Stealth</td>
+      <td align="left">Whether the armor gives disadvantage for Stealth.</td>
       <td align="left">boolean</td>
     </tr>
     <tr>
       <td align="left">weight</td>
-      <td align="left">How much the equipment weighs</td>
+      <td align="left">How much the equipment weighs.</td>
       <td align="left">integer</td>
     </tr>
     <tr>
       <td align="left">cost</td>
-      <td align="left">The cost of the equipment</td>
+      <td align="left">The cost of the equipment.</td>
       <td align="left"><a href="#cost">Cost</a></td>
     </tr>
     <tr>
       <td align="left">url</td>
-      <td align="left">The URL of the referenced resource</td>
+      <td align="left">The URL of the referenced resource.</td>
       <td align="left">string</td>
     </tr>
   </tbody>
@@ -264,17 +264,17 @@
   <tbody>
     <tr>
       <td align="left">index</td>
-      <td align="left">The damage type index for shorthand searching</td>
+      <td align="left">The damage type index for shorthand searching.</td>
       <td align="left">string</td>
     </tr>
     <tr>
       <td align="left">name</td>
-      <td align="left">The name for this equipment resource</td>
+      <td align="left">The name for this equipment resource.</td>
       <td align="left">string</td>
     </tr>
     <tr>
       <td align="left">equipment_category</td>
-      <td align="left">The category of equipment this falls into</td>
+      <td align="left">The category of equipment this falls into.</td>
       <td align="left">
         <a href="#apireference">APIReference</a> (<a href="#equipment-categories"
           >Equipment Categories</a
@@ -283,7 +283,7 @@
     </tr>
     <tr>
       <td align="left">gear_category</td>
-      <td align="left">The category of adventuring gear this falls into</td>
+      <td align="left">The category of adventuring gear this falls into.</td>
       <td align="left">
         <a href="#apireference">APIReference</a> (<a href="#equipment-categories"
           >Equipment Categories</a
@@ -292,17 +292,17 @@
     </tr>
     <tr>
       <td align="left">cost</td>
-      <td align="left">The cost of the equipment</td>
+      <td align="left">The cost of the equipment.</td>
       <td align="left"><a href="#cost">Cost</a></td>
     </tr>
     <tr>
       <td align="left">weight</td>
-      <td align="left">How much the equipment weighs</td>
+      <td align="left">How much the equipment weighs.</td>
       <td align="left">integer</td>
     </tr>
     <tr>
       <td align="left">url</td>
-      <td align="left">The URL of the referenced resource</td>
+      <td align="left">The URL of the referenced resource.</td>
       <td align="left">string</td>
     </tr>
   </tbody>
@@ -441,17 +441,17 @@
   <tbody>
     <tr>
       <td align="left">index</td>
-      <td align="left">The damage type index for shorthand searching</td>
+      <td align="left">The damage type index for shorthand searching.</td>
       <td align="left">string</td>
     </tr>
     <tr>
       <td align="left">name</td>
-      <td align="left">The name for this equipment resource</td>
+      <td align="left">The name for this equipment resource.</td>
       <td align="left">string</td>
     </tr>
     <tr>
       <td align="left">equipment_category</td>
-      <td align="left">The category of equipment this falls into</td>
+      <td align="left">The category of equipment this falls into.</td>
       <td align="left">
         <a href="#apireference">APIReference</a> (<a href="#equipment-categories"
           >Equipment Categories</a
@@ -460,7 +460,7 @@
     </tr>
     <tr>
       <td align="left">gear_category</td>
-      <td align="left">The category of adventuring gear this falls into</td>
+      <td align="left">The category of adventuring gear this falls into.</td>
       <td align="left">
         <a href="#apireference">APIReference</a> (<a href="#equipment-categories"
           >Equipment Categories</a
@@ -469,19 +469,19 @@
     </tr>
     <tr>
       <td align="left">cost</td>
-      <td align="left">The cost of the equipment</td>
+      <td align="left">The cost of the equipment.</td>
       <td align="left"><a href="#cost">Cost</a></td>
     </tr>
     <tr>
       <td align="left">contents</td>
-      <td align="left">The list of adventuring gear in the pack</td>
+      <td align="left">The list of adventuring gear in the pack.</td>
       <td align="left">
         list <a href="#apireference">APIReference</a> (<a href="#equipment-gear">Equipment</a>)
       </td>
     </tr>
     <tr>
       <td align="left">url</td>
-      <td align="left">The URL of the referenced resource</td>
+      <td align="left">The URL of the referenced resource.</td>
       <td align="left">string</td>
     </tr>
   </tbody>

--- a/src/views/partials/doc-resource-features.ejs
+++ b/src/views/partials/doc-resource-features.ejs
@@ -36,12 +36,12 @@
   <tbody>
     <tr>
       <td align="left">index</td>
-      <td align="left">The feature index for shorthand searching</td>
+      <td align="left">The feature index for shorthand searching.</td>
       <td align="left">string</td>
     </tr>
     <tr>
       <td align="left">name</td>
-      <td align="left">The name for this feature resource</td>
+      <td align="left">The name for this feature resource.</td>
       <td align="left">string</td>
     </tr>
     <tr>
@@ -58,19 +58,19 @@
     </tr>
     <tr>
       <td align="left">subclass</td>
-      <td align="left">The subclass that gains feature resource</td>
+      <td align="left">The subclass that gains feature resource.</td>
       <td align="left">
         <a href="#apireference">APIReference</a> (<a href="#subclasses">Subclass</a>)
       </td>
     </tr>
     <tr>
       <td align="left">desc</td>
-      <td align="left">A brief description of the feature</td>
+      <td align="left">A brief description of the feature.</td>
       <td align="left">list string</td>
     </tr>
     <tr>
       <td align="left">url</td>
-      <td align="left">The URL of the referenced resource</td>
+      <td align="left">The URL of the referenced resource.</td>
       <td align="left">string</td>
     </tr>
   </tbody>

--- a/src/views/partials/doc-resource-languages.ejs
+++ b/src/views/partials/doc-resource-languages.ejs
@@ -27,32 +27,32 @@
   <tbody>
     <tr>
       <td align="left">index</td>
-      <td align="left">The language index for shorthand searching</td>
+      <td align="left">The language index for shorthand searching.</td>
       <td align="left">string</td>
     </tr>
     <tr>
       <td align="left">name</td>
-      <td align="left">The name of this language resource</td>
+      <td align="left">The name of this language resource.</td>
       <td align="left">string</td>
     </tr>
     <tr>
       <td align="left">type</td>
-      <td align="left">Whether the language is standard or exotic</td>
+      <td align="left">Whether the language is standard or exotic.</td>
       <td align="left">string</td>
     </tr>
     <tr>
       <td align="left">typical_speakers</td>
-      <td align="left">Races that tend to speak this language</td>
+      <td align="left">Races that tend to speak this language.</td>
       <td align="left">array string</td>
     </tr>
     <tr>
       <td align="left">script</td>
-      <td align="left">The script used for writing in this language</td>
+      <td align="left">The script used for writing in this language.</td>
       <td align="left">string</td>
     </tr>
     <tr>
       <td align="left">url</td>
-      <td align="left">The URL of the referenced resource</td>
+      <td align="left">The URL of the referenced resource.</td>
       <td align="left">string</td>
     </tr>
   </tbody>

--- a/src/views/partials/doc-resource-lists.ejs
+++ b/src/views/partials/doc-resource-lists.ejs
@@ -68,7 +68,7 @@
   <tbody>
     <tr>
       <td align="left">name</td>
-      <td align="left">A case insensitive query parameter for the name</td>
+      <td align="left">A case insensitive query parameter for the name.</td>
     </tr>
   </tbody>
 </table>
@@ -86,12 +86,12 @@
   <tbody>
     <tr>
       <td align="left">count</td>
-      <td align="left">Total number of resource available from this API</td>
+      <td align="left">Total number of resource available from this API.</td>
       <td align="left">integer</td>
     </tr>
     <tr>
       <td align="left">results</td>
-      <td align="left">A list of named API resource lists</td>
+      <td align="left">A list of named API resource lists.</td>
       <td align="left">list <a href="#apireference">APIReference</a></td>
     </tr>
   </tbody>
@@ -140,12 +140,12 @@
   <tbody>
     <tr>
       <td align="left">count</td>
-      <td align="left">Total number of resource available from this API</td>
+      <td align="left">Total number of resource available from this API.</td>
       <td align="left">integer</td>
     </tr>
     <tr>
       <td align="left">results</td>
-      <td align="left">A list of class API resource lists</td>
+      <td align="left">A list of class API resource lists.</td>
       <td align="left">list <a href="#classapiresource">ClassAPIResource</a></td>
     </tr>
   </tbody>

--- a/src/views/partials/doc-resource-magic-items.ejs
+++ b/src/views/partials/doc-resource-magic-items.ejs
@@ -31,13 +31,13 @@
   <tbody>
     <tr>
       <td align="left">index</td>
-      <td align="left">The magic item index for shorthand searching</td>
+      <td align="left">The magic item index for shorthand searching.</td>
       <td align="left">string</td>
     </tr>
 
     <tr>
       <td align="left">name</td>
-      <td align="left">The name of the magic item</td>
+      <td align="left">The name of the magic item.</td>
       <td align="left">string</td>
     </tr>
 
@@ -51,7 +51,7 @@
 
     <tr>
       <td align="left">desc</td>
-      <td align="left">A description of the magic item</td>
+      <td align="left">A description of the magic item.</td>
       <td align="left">list string</td>
     </tr>
   </tbody>

--- a/src/views/partials/doc-resource-magic-schools.ejs
+++ b/src/views/partials/doc-resource-magic-schools.ejs
@@ -28,22 +28,22 @@
   <tbody>
     <tr>
       <td align="left">index</td>
-      <td align="left">The magic school index for shorthand searching</td>
+      <td align="left">The magic school index for shorthand searching.</td>
       <td align="left">string</td>
     </tr>
     <tr>
       <td align="left">name</td>
-      <td align="left">The name for this magic school resource</td>
+      <td align="left">The name for this magic school resource.</td>
       <td align="left">string</td>
     </tr>
     <tr>
       <td align="left">desc</td>
-      <td align="left">A brief description of the magic school</td>
+      <td align="left">A brief description of the magic school.</td>
       <td align="left">string</td>
     </tr>
     <tr>
       <td align="left">url</td>
-      <td align="left">The URL of the referenced resource</td>
+      <td align="left">The URL of the referenced resource.</td>
       <td align="left">string</td>
     </tr>
   </tbody>

--- a/src/views/partials/doc-resource-monsters.ejs
+++ b/src/views/partials/doc-resource-monsters.ejs
@@ -221,27 +221,27 @@
   <tbody>
     <tr>
       <td align="left">index</td>
-      <td align="left">The monster index for shorthand searching</td>
+      <td align="left">The monster index for shorthand searching.</td>
       <td align="left">string</td>
     </tr>
     <tr>
       <td align="left">name</td>
-      <td align="left">The name of the monster</td>
+      <td align="left">The name of the monster.</td>
       <td align="left">string</td>
     </tr>
     <tr>
       <td align="left">size</td>
-      <td align="left">The size of the monster ranging from Tiny to Gargantuan</td>
+      <td align="left">The size of the monster ranging from Tiny to Gargantuan.</td>
       <td align="left">string</td>
     </tr>
     <tr>
       <td align="left">type</td>
-      <td align="left">The type of monster</td>
+      <td align="left">The type of monster.</td>
       <td align="left">string</td>
     </tr>
     <tr>
       <td align="left">subtype</td>
-      <td align="left">The sub-category of a monster used for classification of monsters</td>
+      <td align="left">The sub-category of a monster used for classification of monsters.</td>
       <td align="left">string</td>
     </tr>
     <tr>
@@ -253,7 +253,7 @@
     </tr>
     <tr>
       <td align="left">armor_class</td>
-      <td align="left">The difficulty for a player to successfully deal damage to a monster</td>
+      <td align="left">The difficulty for a player to successfully deal damage to a monster.</td>
       <td align="left">integer</td>
     </tr>
     <tr>
@@ -280,7 +280,7 @@
     </tr>
     <tr>
       <td align="left">strength</td>
-      <td align="left">The strength of a monster. How hard a monster can hit a player</td>
+      <td align="left">The strength of a monster. How hard a monster can hit a player.</td>
       <td align="left">integer</td>
     </tr>
     <tr>
@@ -292,7 +292,7 @@
     </tr>
     <tr>
       <td align="left">constitution</td>
-      <td align="left">The constitution of a monster. How sturdy a monster is</td>
+      <td align="left">The constitution of a monster. How sturdy a monster is.</td>
 
       <td align="left">integer</td>
     </tr>
@@ -319,27 +319,27 @@
     </tr>
     <tr>
       <td align="left">proficiencies</td>
-      <td align="left">A list of proficiencies of a monster</td>
+      <td align="left">A list of proficiencies of a monster.</td>
       <td align="left">list</td>
     </tr>
     <tr>
       <td align="left">damage_vulnerabilities</td>
-      <td align="left">A list of damage types that a monster will take double damage from</td>
+      <td align="left">A list of damage types that a monster will take double damage from.</td>
       <td align="left">list</td>
     </tr>
     <tr>
       <td align="left">damage_resistances</td>
-      <td align="left">A list of damage types that a monster will take half damage from</td>
+      <td align="left">A list of damage types that a monster will take half damage from.</td>
       <td align="left">list</td>
     </tr>
     <tr>
       <td align="left">damage_immunities</td>
-      <td align="left">A list of damage types that a monster will take zero damage from</td>
+      <td align="left">A list of damage types that a monster will take zero damage from.</td>
       <td align="left">list</td>
     </tr>
     <tr>
       <td align="left">condition_immunities</td>
-      <td align="left">A list of conditions that a monster is immune to</td>
+      <td align="left">A list of conditions that a monster is immune to.</td>
       <td align="left">list</td>
     </tr>
     <tr>
@@ -352,7 +352,7 @@
     </tr>
     <tr>
       <td align="left">languages</td>
-      <td align="left">The languages a monster is able to speak</td>
+      <td align="left">The languages a monster is able to speak.</td>
       <td align="left">string</td>
     </tr>
     <tr>
@@ -368,24 +368,24 @@
     </tr>
     <tr>
       <td align="left">special_abilities</td>
-      <td align="left">A list of the monster's special abilities</td>
+      <td align="left">A list of the monster's special abilities.</td>
       <td align="left">list</td>
     </tr>
     <tr>
       <td align="left">actions</td>
-      <td align="left">A list of actions that is available to the monster to take during combat</td>
+      <td align="left">A list of actions that is available to the monster to take during combat.</td>
       <td align="left">list</td>
     </tr>
     <tr>
       <td align="left">legendary_actions</td>
       <td align="left">
-        Certain monsters have a list of actions that can be used outside of the monster's initiative
+        Certain monsters have a list of actions that can be used outside of the monster's initiative.
       </td>
       <td align="left">list</td>
     </tr>
     <tr>
       <td align="left">url</td>
-      <td align="left">The URL of the referenced resource</td>
+      <td align="left">The URL of the referenced resource.</td>
       <td align="left">string</td>
     </tr>
   </tbody>

--- a/src/views/partials/doc-resource-proficiencies.ejs
+++ b/src/views/partials/doc-resource-proficiencies.ejs
@@ -54,17 +54,17 @@
   <tbody>
     <tr>
       <td align="left">index</td>
-      <td align="left">The proficiency index for shorthand searching</td>
+      <td align="left">The proficiency index for shorthand searching.</td>
       <td align="left">string</td>
     </tr>
     <tr>
       <td align="left">type</td>
-      <td align="left">The general category of the proficiency</td>
+      <td align="left">The general category of the proficiency.</td>
       <td align="left">string</td>
     </tr>
     <tr>
       <td align="left">name</td>
-      <td align="left">The name of this proficiency resource</td>
+      <td align="left">The name of this proficiency resource.</td>
       <td align="left">string</td>
     </tr>
     <tr>
@@ -83,12 +83,12 @@
     </tr>
     <tr>
       <td align="left">url</td>
-      <td align="left">The URL of the referenced resource</td>
+      <td align="left">The URL of the referenced resource.</td>
       <td align="left">string</td>
     </tr>
     <tr>
       <td align="left">references</td>
-      <td align="left">list of references</td>
+      <td align="left">list of references.</td>
       <td align="left">
         list <a href="#apireference">APIReference</a> (<a href="#equipment-categories">Equipment Categories</a>)
       </td>

--- a/src/views/partials/doc-resource-races.ejs
+++ b/src/views/partials/doc-resource-races.ejs
@@ -125,17 +125,17 @@
     </tr>
     <tr>
       <td align="left">name</td>
-      <td align="left">The name for this race resource</td>
+      <td align="left">The name for this race resource.</td>
       <td align="left">string</td>
     </tr>
     <tr>
       <td align="left">speed</td>
-      <td align="left">Base move speed for this race (in feet per round)</td>
+      <td align="left">Base move speed for this race (in feet per round).</td>
       <td align="left">integer</td>
     </tr>
     <tr>
       <td align="left">ability_bonuses</td>
-      <td align="left">Racial bonuses to each of the six ability scores</td>
+      <td align="left">Racial bonuses to each of the six ability scores.</td>
       <td align="left">array (integer)</td>
     </tr>
     <tr>
@@ -145,22 +145,22 @@
     </tr>
     <tr>
       <td align="left">age</td>
-      <td align="left">Flavor description of possible ages for this race</td>
+      <td align="left">Flavor description of possible ages for this race.</td>
       <td align="left">string</td>
     </tr>
     <tr>
       <td align="left">size</td>
-      <td align="left">Size class of this race</td>
+      <td align="left">Size class of this race.</td>
       <td align="left">string</td>
     </tr>
     <tr>
       <td align="left">size_description</td>
-      <td align="left">Flavor description of height and weight for this race</td>
+      <td align="left">Flavor description of height and weight for this race.</td>
       <td align="left">string</td>
     </tr>
     <tr>
       <td align="left">starting_proficiencies</td>
-      <td align="left">Starting proficiencies for all new characters of this race</td>
+      <td align="left">Starting proficiencies for all new characters of this race.</td>
       <td align="left">
         list <a href="#apireference">APIReference</a> (<a href="#proficiencies"
           >Proficiencies</a
@@ -169,7 +169,7 @@
     </tr>
     <tr>
       <td align="left">languages</td>
-      <td align="left">Starting languages for all new characters of this race</td>
+      <td align="left">Starting languages for all new characters of this race.</td>
       <td align="left">
         list <a href="#apireference">APIReference</a> (<a href="#languages">Proficiencies</a
         >)
@@ -177,12 +177,12 @@
     </tr>
     <tr>
       <td align="left">language_desc</td>
-      <td align="left">Flavor description of the languages this race knows</td>
+      <td align="left">Flavor description of the languages this race knows.</td>
       <td align="left">string</td>
     </tr>
     <tr>
       <td align="left">traits</td>
-      <td align="left">Racial traits that provide benefits to its members</td>
+      <td align="left">Racial traits that provide benefits to its members.</td>
       <td align="left">
         list <a href="#apireference">APIReference</a> (<a href="#traits">Trait</a>)
       </td>
@@ -231,13 +231,13 @@
   <tbody>
     <tr>
       <td align="left">count</td>
-      <td align="left">the number of available subraces</td>
+      <td align="left">the number of available subraces.</td>
       <td align="left">integer</td>
     </tr>
 
     <tr>
       <td align="left">results</td>
-      <td align="left">A list of the subrace and its reference url</td>
+      <td align="left">A list of the subrace and its reference url.</td>
       <td align="left">
         list <a href="#apireference">APIReference</a> (<a href="#subraces">Subrace</a>)
       </td>
@@ -271,13 +271,13 @@
   <tbody>
     <tr>
       <td align="left">count</td>
-      <td align="left">the number of proficiencies available to a race</td>
+      <td align="left">the number of proficiencies available to a race.</td>
       <td align="left">integer</td>
     </tr>
 
     <tr>
       <td align="left">results</td>
-      <td align="left">A list of the available proficiencies for a race</td>
+      <td align="left">A list of the available proficiencies for a race.</td>
       <td align="left">
         list <a href="#apireference">APIReference</a> (<a href="#proficiencies">Proficiencies</a>)
       </td>
@@ -317,13 +317,13 @@
   <tbody>
     <tr>
       <td align="left">count</td>
-      <td align="left">the number of traits available to a race</td>
+      <td align="left">the number of traits available to a race.</td>
       <td align="left">integer</td>
     </tr>
 
     <tr>
       <td align="left">results</td>
-      <td align="left">A list of the available traits for a race</td>
+      <td align="left">A list of the available traits for a race.</td>
       <td align="left">
         list <a href="#apireference">APIReference</a> (<a href="#traits">Traits</a>)
       </td>

--- a/src/views/partials/doc-resource-rule-sections.ejs
+++ b/src/views/partials/doc-resource-rule-sections.ejs
@@ -25,22 +25,22 @@
     <tbody>
     <tr>
         <td align="left">index</td>
-        <td align="left">The rule section index for shorthand searching</td>
+        <td align="left">The rule section index for shorthand searching.</td>
         <td align="left">string</td>
     </tr>
     <tr>
         <td align="left">name</td>
-        <td align="left">The heading of this rule section</td>
+        <td align="left">The heading of this rule section.</td>
         <td align="left">string</td>
     </tr>
     <tr>
         <td align="left">desc</td>
-        <td align="left">Markdown for the text directly underneath the section heading in the SRD</td>
+        <td align="left">Markdown for the text directly underneath the section heading in the SRD.</td>
         <td align="left">string</td>
     </tr>
     <tr>
         <td align="left">url</td>
-        <td align="left">The URL of the referenced resource</td>
+        <td align="left">The URL of the referenced resource.</td>
         <td align="left">string</td>
     </tr>
     </tbody>

--- a/src/views/partials/doc-resource-rules.ejs
+++ b/src/views/partials/doc-resource-rules.ejs
@@ -59,22 +59,22 @@
     <tbody>
     <tr>
         <td align="left">index</td>
-        <td align="left">The rule index for shorthand searching</td>
+        <td align="left">The rule index for shorthand searching.</td>
         <td align="left">string</td>
     </tr>
     <tr>
         <td align="left">name</td>
-        <td align="left">The heading of this rule</td>
+        <td align="left">The heading of this rule.</td>
         <td align="left">string</td>
     </tr>
     <tr>
         <td align="left">desc</td>
-        <td align="left">Markdown for the text directly underneath the rule heading in the SRD</td>
+        <td align="left">Markdown for the text directly underneath the rule heading in the SRD.</td>
         <td align="left">string</td>
     </tr>
     <tr>
         <td align="left">subsections</td>
-        <td align="left">Sections for each subheading underneath the rule in the SRD</td>
+        <td align="left">Sections for each subheading underneath the rule in the SRD.</td>
         <td align="left">
             list <a href="#apireference">APIReference</a> (<a href="#rule-sections"
             >Rule Section</a
@@ -83,7 +83,7 @@
     </tr>
     <tr>
         <td align="left">url</td>
-        <td align="left">The URL of the referenced resource</td>
+        <td align="left">The URL of the referenced resource.</td>
         <td align="left">string</td>
     </tr>
     </tbody>

--- a/src/views/partials/doc-resource-skills.ejs
+++ b/src/views/partials/doc-resource-skills.ejs
@@ -44,7 +44,7 @@
     </tr>
     <tr>
       <td align="left">desc</td>
-      <td align="left">A brief description on this skill and its uses</td>
+      <td align="left">A brief description of this skill and its uses</td>
       <td align="left">list string</td>
     </tr>
     <tr>

--- a/src/views/partials/doc-resource-skills.ejs
+++ b/src/views/partials/doc-resource-skills.ejs
@@ -34,17 +34,17 @@
   <tbody>
     <tr>
       <td align="left">index</td>
-      <td align="left">The skill index for shorthand searching</td>
+      <td align="left">The skill index for shorthand searching.</td>
       <td align="left">string</td>
     </tr>
     <tr>
       <td align="left">name</td>
-      <td align="left">The abbreviated name for this skill</td>
+      <td align="left">The abbreviated name for this skill.</td>
       <td align="left">string</td>
     </tr>
     <tr>
       <td align="left">desc</td>
-      <td align="left">A brief description of this skill and its uses</td>
+      <td align="left">A brief description of this skill and its uses.</td>
       <td align="left">list string</td>
     </tr>
     <tr>
@@ -58,7 +58,7 @@
     </tr>
     <tr>
       <td align="left">url</td>
-      <td align="left">The URL of the referenced resource</td>
+      <td align="left">The URL of the referenced resource.</td>
       <td align="left">string</td>
     </tr>
   </tbody>

--- a/src/views/partials/doc-resource-spellcasting.ejs
+++ b/src/views/partials/doc-resource-spellcasting.ejs
@@ -100,7 +100,7 @@
 
     <tr>
       <td align="left">spellcasting_ability</td>
-      <td align="left">The attribute used by the spellcasting class</td>
+      <td align="left">The attribute used by the spellcasting class.</td>
       <td align="left">
         <a href="#apireference">APIReference</a> (<a href="#spells">Spells</a>)
       </td>
@@ -108,7 +108,7 @@
 
     <tr>
       <td align="left">info</td>
-      <td align="left">Brief descriptions of the class' ability to cast spells</td>
+      <td align="left">Brief descriptions of the class' ability to cast spells.</td>
       <td align="left">list</td>
     </tr>
 

--- a/src/views/partials/doc-resource-spells.ejs
+++ b/src/views/partials/doc-resource-spells.ejs
@@ -124,24 +124,24 @@
   <tbody>
     <tr>
       <td align="left">index</td>
-      <td align="left">The spell index for shorthand searching</td>
+      <td align="left">The spell index for shorthand searching.</td>
       <td align="left">string</td>
     </tr>
     <tr>
       <td align="left">desc</td>
-      <td align="left">A description of the spell</td>
+      <td align="left">A description of the spell.</td>
       <td align="left">list</td>
     </tr>
 
     <tr>
       <td align="left">higher_level</td>
-      <td align="left">description for casting the spell at a higher level</td>
+      <td align="left">description for casting the spell at a higher level.</td>
       <td align="left">list</td>
     </tr>
 
     <tr>
       <td align="left">range</td>
-      <td align="left">The range of the spell</td>
+      <td align="left">The range of the spell.</td>
       <td align="left">string</td>
     </tr>
 
@@ -149,50 +149,50 @@
       <td align="left">components</td>
       <td align="left">
         The required components for a spell are shorthanded to V,S, and M which stand for verbal,
-        somatic, and material
+        somatic, and material.
       </td>
       <td align="left">list</td>
     </tr>
 
     <tr>
       <td align="left">material</td>
-      <td align="left">The material component for the spell to be cast</td>
+      <td align="left">The material component for the spell to be cast.</td>
       <td align="left">string</td>
     </tr>
 
     <tr>
       <td align="left">ritual</td>
-      <td align="left">Determines if a spell can be cast in a 10-min(in-game) ritual</td>
+      <td align="left">Determines if a spell can be cast in a 10-min(in-game) ritual.</td>
       <td align="left">boolean</td>
     </tr>
 
     <tr>
       <td align="left">duration</td>
-      <td align="left">How long the spell effect lasts</td>
+      <td align="left">How long the spell effect lasts.</td>
       <td align="left">string</td>
     </tr>
 
     <tr>
       <td align="left">concentration</td>
-      <td align="left">Determines if a spell needs concentration to persist</td>
+      <td align="left">Determines if a spell needs concentration to persist.</td>
       <td align="left">boolean</td>
     </tr>
 
     <tr>
       <td align="left">casting_time</td>
-      <td align="left">How long it takes for the spell to activate</td>
+      <td align="left">How long it takes for the spell to activate.</td>
       <td align="left">string</td>
     </tr>
 
     <tr>
       <td align="left">level</td>
-      <td align="left">The level of the spell</td>
+      <td align="left">The level of the spell.</td>
       <td align="left">integer</td>
     </tr>
 
     <tr>
       <td align="left">attack_type</td>
-      <td align="left">The attack type of the spell</td>
+      <td align="left">The attack type of the spell.</td>
       <td align="left">string</td>
     </tr>
 
@@ -206,7 +206,7 @@
 
     <tr>
       <td align="left">school</td>
-      <td align="left">The magic school this spell belongs to</td>
+      <td align="left">The magic school this spell belongs to.</td>
       <td align="left">
         <a href="#apireference">APIReference</a> (<a href="#magic-schools">Magic Schools</a>)
       </td>
@@ -214,7 +214,7 @@
 
     <tr>
       <td align="left">classes</td>
-      <td align="left">The classes that are able to learn this spell</td>
+      <td align="left">The classes that are able to learn this spell.</td>
       <td align="left">
         <a href="#apireference">APIReference</a> (<a href="#classes">Classes</a>)
       </td>
@@ -222,7 +222,7 @@
 
     <tr>
       <td align="left">subclasses</td>
-      <td align="left">A list of subclasses that have access to this spell</td>
+      <td align="left">A list of subclasses that have access to this spell.</td>
       <td align="left">
         list<a href="#apireference">APIReference</a> (<a href="#classes">Classes</a>)
       </td>

--- a/src/views/partials/doc-resource-starting-equipment.ejs
+++ b/src/views/partials/doc-resource-starting-equipment.ejs
@@ -145,7 +145,7 @@
 
     <tr>
       <td align="left">starting_equipment</td>
-      <td align="left">The starting equipment a character automatically gets</td>
+      <td align="left">The starting equipment a character automatically gets.</td>
       <td align="left">
         list <a href="#apireference">APIReference</a> (<a href="#equipment">Equipment</a>)
       </td>
@@ -155,7 +155,7 @@
       <td align="left">starting_equipment_options</td>
       <td align="left">
         Starting equipment where the player must choose a certain number from the given list of
-        equipment
+        equipment.
       </td>
       <td align="left">list <a href="#choice">Choice</a> (<a href="#equipment">Equipment</a>)</td>
     </tr>

--- a/src/views/partials/doc-resource-subclasses.ejs
+++ b/src/views/partials/doc-resource-subclasses.ejs
@@ -181,7 +181,7 @@
     </tr>
     <tr>
       <td align="left">name</td>
-      <td align="left">The name for this subclass resource</td>
+      <td align="left">The name for this subclass resource.</td>
       <td align="left">string</td>
     </tr>
     <tr>
@@ -196,12 +196,12 @@
     </tr>
     <tr>
       <td align="left">spells</td>
-      <td align="left">A list of spells that class can obtain at certain level thresholds</td>
+      <td align="left">A list of spells that class can obtain at certain level thresholds.</td>
       <td align="left">list</td>
     </tr>
     <tr>
       <td align="left">subclass_levels</td>
-      <td align="left">A resource url that shows the subclass level progression </td>
+      <td align="left">A resource url that shows the subclass level progression .</td>
       <td align="left">
         <a href="#apireference">APIReference</a> (<a href="#levels">Levels</a>)
       </td>
@@ -246,13 +246,13 @@
   <tbody>
     <tr>
       <td align="left">count</td>
-      <td align="left">the number of features available to a subclass</td>
+      <td align="left">the number of features available to a subclass.</td>
       <td align="left">integer</td>
     </tr>
 
     <tr>
       <td align="left">results</td>
-      <td align="left">A list of the available features for a subclass</td>
+      <td align="left">A list of the available features for a subclass.</td>
       <td align="left">
         list <a href="#apireference">APIReference</a> (<a href="#features">Features</a>)
       </td>
@@ -330,13 +330,13 @@
   <tbody>
     <tr>
       <td align="left">level</td>
-      <td align="left">The level that the subclass gets access to this feature</td>
+      <td align="left">The level that the subclass gets access to this feature.</td>
       <td align="left">integer</td>
     </tr>
 
     <tr>
       <td align="left">feature_choices</td>
-      <td align="left">A list of the available feature choices for a subclass</td>
+      <td align="left">A list of the available feature choices for a subclass.</td>
       <td align="left">
         list <a href="#apireference">APIReference</a> (<a href="#features">Features</a>)
       </td>
@@ -344,7 +344,7 @@
 
     <tr>
       <td align="left">features</td>
-      <td align="left">The feature available for a subclass</td>
+      <td align="left">The feature available for a subclass.</td>
       <td align="left">
         list <a href="#apireference">APIReference</a> (<a href="#features">Features</a>)
       </td>
@@ -352,7 +352,7 @@
 
     <tr>
       <td align="left">class</td>
-      <td align="left">The class that has access to subclass feature</td>
+      <td align="left">The class that has access to subclass feature.</td>
       <td align="left">
         <a href="#apireference">APIReference</a> (<a href="#classes">Classes</a>)
       </td>
@@ -360,7 +360,7 @@
 
     <tr>
       <td align="left">subclass</td>
-      <td align="left">The subclass name</td>
+      <td align="left">The subclass name.</td>
       <td align="left">
         <a href="#apireference">APIReference</a> (<a href="#subclasses">Subclasses</a>)
       </td>
@@ -423,13 +423,13 @@
   <tbody>
     <tr>
       <td align="left">level</td>
-      <td align="left">The level that the subclass gets access to this feature</td>
+      <td align="left">The level that the subclass gets access to this feature.</td>
       <td align="left">integer</td>
     </tr>
 
     <tr>
       <td align="left">feature_choices</td>
-      <td align="left">A list of the available feature choices for a subclass</td>
+      <td align="left">A list of the available feature choices for a subclass.</td>
       <td align="left">
         list <a href="#apireference">APIReference</a> (<a href="#features">Features</a>)
       </td>
@@ -437,7 +437,7 @@
 
     <tr>
       <td align="left">features</td>
-      <td align="left">The feature available for a subclass</td>
+      <td align="left">The feature available for a subclass.</td>
       <td align="left">
         list <a href="#apireference">APIReference</a> (<a href="#features">Features</a>)
       </td>
@@ -445,7 +445,7 @@
 
     <tr>
       <td align="left">classe</td>
-      <td align="left">The class that has access to subclass feature</td>
+      <td align="left">The class that has access to subclass feature.</td>
       <td align="left">
         <a href="#apireference">APIReference</a> (<a href="#classes">Classes</a>)
       </td>
@@ -453,7 +453,7 @@
 
     <tr>
       <td align="left">subclass</td>
-      <td align="left">The subclass name</td>
+      <td align="left">The subclass name.</td>
       <td align="left">
         <a href="#apireference">APIReference</a> (<a href="#subclasses">Subclasses</a>)
       </td>
@@ -497,13 +497,13 @@
   </thead>
   <tbody><tr>
     <td align="left">count</td>
-    <td align="left">The number of features available at the requested level</td>
+    <td align="left">The number of features available at the requested level.</td>
     <td align="left">integer</td>
   </tr>
 
   <tr>
     <td align="left">results</td>
-    <td align="left">A list of the available feature choices for a subclass at the requested level</td>
+    <td align="left">A list of the available feature choices for a subclass at the requested level.</td>
     <td align="left">
       list <a href="#apireference">APIReference</a> (<a href="#features">Features</a>)
     </td>

--- a/src/views/partials/doc-resource-subraces.ejs
+++ b/src/views/partials/doc-resource-subraces.ejs
@@ -50,7 +50,7 @@
     </tr>
     <tr>
       <td align="left">name</td>
-      <td align="left">The name for this subrace resource</td>
+      <td align="left">The name for this subrace resource.</td>
       <td align="left">string</td>
     </tr>
     <tr>
@@ -62,17 +62,17 @@
     </tr>
     <tr>
       <td align="left">desc</td>
-      <td align="left">Flavor description of this subrace</td>
+      <td align="left">Flavor description of this subrace.</td>
       <td align="left">string</td>
     </tr>
     <tr>
       <td align="left">ability_bonuses</td>
-      <td align="left">Additional ability bonuses granted by this sub race</td>
+      <td align="left">Additional ability bonuses granted by this sub race.</td>
       <td align="left">array (map)</td>
     </tr>
     <tr>
       <td align="left">starting_proficiencies</td>
-      <td align="left">Starting proficiencies for all new characters of this subrace</td>
+      <td align="left">Starting proficiencies for all new characters of this subrace.</td>
       <td align="left">
         list <a href="#apireference">APIReference</a> (<a href="#proficiencies"
           >Proficiencies</a
@@ -81,7 +81,7 @@
     </tr>
     <tr>
       <td align="left">languages</td>
-      <td align="left">Starting languages for all new characters of this subrace</td>
+      <td align="left">Starting languages for all new characters of this subrace.</td>
       <td align="left">
         list <a href="#apireference">APIReference</a> (<a href="#languages">Proficiencies</a
         >)
@@ -89,7 +89,7 @@
     </tr>
     <tr>
       <td align="left">traits</td>
-      <td align="left">Racial traits that provide benefits to its members</td>
+      <td align="left">Racial traits that provide benefits to its members.</td>
       <td align="left">
         list <a href="#apireference">APIReference</a> (<a href="#traits">Trait</a>)
       </td>
@@ -134,12 +134,12 @@
   <tbody>
     <tr>
       <td align="left">count</td>
-      <td align="left">The number of traits that apply to a subrace</td>
+      <td align="left">The number of traits that apply to a subrace.</td>
       <td align="left">integer</td>
     </tr>
     <tr>
       <td align="left">results</td>
-      <td align="left">Subracial traits that provide benefits to its members</td>
+      <td align="left">Subracial traits that provide benefits to its members.</td>
       <td align="left">
         list <a href="#apireference">APIReference</a> (<a href="#traits">Traits</a>)
       </td>
@@ -178,12 +178,12 @@
   </thead>
   <tbody><tr>
     <td align="left">count</td>
-    <td align="left">The number of proficiences that apply to a subrace</td>
+    <td align="left">The number of proficiences that apply to a subrace.</td>
     <td align="left">integer</td>
   </tr>
   <tr>
     <td align="left">results</td>
-    <td align="left">Subracial proficiences that provide benefits to its members</td>
+    <td align="left">Subracial proficiences that provide benefits to its members.</td>
     <td align="left">
       list <a href="#apireference">APIReference</a> (<a href="#proficiences">Proficiencies</a>)
     </td>

--- a/src/views/partials/doc-resource-traits.ejs
+++ b/src/views/partials/doc-resource-traits.ejs
@@ -40,38 +40,38 @@
     </tr>
     <tr>
       <td align="left">races</td>
-      <td align="left">Races that have access to the trait</td>
+      <td align="left">Races that have access to the trait.</td>
       <td align="left">
         list <a href="#apireference">APIReference</a> (<a href="#proficiences">Proficiencies</a>)
       </td>
     </tr>
     <tr>
       <td align="left">subraces</td>
-      <td align="left">Subraces that have access to the trait</td>
+      <td align="left">Subraces that have access to the trait.</td>
       <td align="left">
         list <a href="#apireference">APIReference</a> (<a href="#proficiences">Proficiencies</a>)
       </td>
     </tr>
     <tr>
       <td align="left">name</td>
-      <td align="left">The name of the trait</td>
+      <td align="left">The name of the trait.</td>
       <td align="left">string</td>
     </tr>
     <tr>
       <td align="left">desc</td>
-      <td align="left">The description of the trait</td>
+      <td align="left">The description of the trait.</td>
       <td align="left">array</td>
     </tr>
     <tr>
       <td align="left">proficiencies</td>
-      <td align="left">Proficiencies this trait grants</td>
+      <td align="left">Proficiencies this trait grants.</td>
       <td align="left">
         list <a href="#apireference">APIReference</a> (<a href="#proficiencies">Proficiencies</a>)
       </td>
     </tr>
     <tr>
       <td align="left">proficiency_choices</td>
-      <td align="left">A choice of proficiencies this trait grants</td>
+      <td align="left">A choice of proficiencies this trait grants.</td>
       <td align="left">list <a href="#choice">Choice</a> (<a href="#proficiencies">Proficiencies</a>)</td>
     </tr>
     <tr>

--- a/src/views/partials/doc-resource-weapon-properties.ejs
+++ b/src/views/partials/doc-resource-weapon-properties.ejs
@@ -33,12 +33,12 @@
     </tr>
     <tr>
       <td align="left">name</td>
-      <td align="left">The name of the weapon property</td>
+      <td align="left">The name of the weapon property.</td>
       <td align="left">string</td>
     </tr>
     <tr>
       <td align="left">desc</td>
-      <td align="left">The description of the weapon property</td>
+      <td align="left">The description of the weapon property.</td>
       <td align="left">array</td>
     </tr>
     <tr>


### PR DESCRIPTION
## What does this do?
- Fixes a few small typos in the descriptions for `Ability Score` and `Skill`
- Adds missing periods to all field descriptions
  - Some descriptions ended with periods, some didn't, this standardizes it so they all end in periods

## How was it tested?
Tested locally with these steps:
- Run `docker-compose up --build`
- Spot checked `http://localhost:3000/docs`

## Is there a Github issue this is resolving?
No

## Here's a fun image for your troubles
![random photo - update me](https://picsum.photos/200)
