### PR TITLE
ecs: small documentation improvements (2)

### DIFF
--- a/src/views/partials/doc-resource-traits.ejs
+++ b/src/views/partials/doc-resource-traits.ejs
@@ -60,7 +60,7 @@
     <tr>
       <td align="left">desc</td>
       <td align="left">The description of the trait.</td>
-      <td align="left">array</td>
+      <td align="left">list string</td>
     </tr>
     <tr>
       <td align="left">proficiencies</td>

--- a/src/views/partials/doc-resource-weapon-properties.ejs
+++ b/src/views/partials/doc-resource-weapon-properties.ejs
@@ -39,7 +39,7 @@
     <tr>
       <td align="left">desc</td>
       <td align="left">The description of the weapon property.</td>
-      <td align="left">array</td>
+      <td align="left">list string</td>
     </tr>
     <tr>
       <td align="left">url</td>


### PR DESCRIPTION
## What does this do?
- update documentation for `desc` field on `Trait` to be list of string rather than array
- update documentation for `desc` field on `WeaponProperty` to be list of string rather than array

## How was it tested?
- spot checked localhost

## Is there a Github issue this is resolving?
no

## Here's a fun image for your troubles
![random photo - update me](https://picsum.photos/200)
