### PR TITLE
Upgrade node docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:12.4.0-alpine
+FROM node:14.15.0-alpine
 
 ## Add code
 WORKDIR /app


### PR DESCRIPTION
## What does this do?
Converts Dockerfile to use the node-14.15 image.

## How was it tested?
`docker build .` and CI

## Is there a Github issue this is resolving?
No

## Here's a fun image for your troubles
![random photo - update me](https://picsum.photos/200)
