### PR TITLE
Rename to APIReference

### DIFF
--- a/src/models/abilityScore.js
+++ b/src/models/abilityScore.js
@@ -1,6 +1,6 @@
 const mongoose = require('mongoose');
 const Schema = mongoose.Schema;
-const { NamedAPIResource } = require('./common');
+const { APIReference } = require('./common');
 
 const AbilityScore = new Schema({
   _id: {
@@ -11,7 +11,7 @@ const AbilityScore = new Schema({
   full_name: String,
   index: String,
   name: String,
-  skills: [NamedAPIResource],
+  skills: [APIReference],
   url: String,
 });
 

--- a/src/models/class.js
+++ b/src/models/class.js
@@ -1,11 +1,11 @@
 const mongoose = require('mongoose');
 const Schema = mongoose.Schema;
-const { NamedAPIResource } = require('./common');
+const { APIReference } = require('./common');
 
 const ProficiencyChoice = new Schema({
   _id: false,
   choose: Number,
-  from: [NamedAPIResource],
+  from: [APIReference],
   type: String,
 });
 
@@ -19,7 +19,7 @@ const Spellcasting = new Schema({
   _id: false,
   info: [SpellcastingInfo],
   level: Number,
-  spellcasting_ability: NamedAPIResource,
+  spellcasting_ability: APIReference,
 });
 
 const Class = new Schema({
@@ -31,13 +31,13 @@ const Class = new Schema({
   hit_die: Number,
   index: String,
   name: String,
-  proficiencies: [NamedAPIResource],
+  proficiencies: [APIReference],
   proficiency_choices: [ProficiencyChoice],
-  saving_throws: [NamedAPIResource],
+  saving_throws: [APIReference],
   spellcasting: Spellcasting,
   spells: String,
   starting_equipment: String,
-  subclasses: [NamedAPIResource],
+  subclasses: [APIReference],
   url: String,
 });
 

--- a/src/models/common.js
+++ b/src/models/common.js
@@ -1,7 +1,7 @@
 const mongoose = require('mongoose');
 const Schema = mongoose.Schema;
 
-const NamedAPIResource = new Schema({
+const APIReference = new Schema({
   _id: false,
   index: String,
   name: String,
@@ -9,5 +9,5 @@ const NamedAPIResource = new Schema({
 });
 
 module.exports = {
-  NamedAPIResource,
+  APIReference,
 };

--- a/src/models/equipment.js
+++ b/src/models/equipment.js
@@ -1,6 +1,6 @@
 const mongoose = require('mongoose');
 const Schema = mongoose.Schema;
-const { NamedAPIResource } = require('./common');
+const { APIReference } = require('./common');
 
 const ArmorClass = new Schema({
   _id: false,
@@ -11,7 +11,7 @@ const ArmorClass = new Schema({
 
 const Content = new Schema({
   _id: false,
-  item: NamedAPIResource,
+  item: APIReference,
   quantity: Number,
 });
 
@@ -24,7 +24,7 @@ const Cost = new Schema({
 const Damage = new Schema({
   _id: false,
   damage_dice: String,
-  damage_type: NamedAPIResource,
+  damage_type: APIReference,
 });
 
 const Range = new Schema({
@@ -48,7 +48,7 @@ const ThrowRange = new Schema({
 const TwoHandedDamage = new Schema({
   _id: false,
   damage_dice: String,
-  damage_type: NamedAPIResource,
+  damage_type: APIReference,
 });
 
 const Equipment = new Schema({
@@ -64,11 +64,11 @@ const Equipment = new Schema({
   cost: Cost,
   damage: Damage,
   desc: [String],
-  equipment_category: NamedAPIResource,
-  gear_category: NamedAPIResource,
+  equipment_category: APIReference,
+  gear_category: APIReference,
   index: String,
   name: String,
-  properties: [NamedAPIResource],
+  properties: [APIReference],
   quantity: Number,
   range: Range,
   special: [String],

--- a/src/models/equipmentCategory.js
+++ b/src/models/equipmentCategory.js
@@ -1,13 +1,13 @@
 const mongoose = require('mongoose');
 const Schema = mongoose.Schema;
-const { NamedAPIResource } = require('./common');
+const { APIReference } = require('./common');
 
 const EquipmentCategory = new Schema({
   _id: {
     type: String,
     select: false,
   },
-  equipment: [NamedAPIResource],
+  equipment: [APIReference],
   index: String,
   name: String,
   url: String,

--- a/src/models/feature.js
+++ b/src/models/feature.js
@@ -1,11 +1,11 @@
 const mongoose = require('mongoose');
 const Schema = mongoose.Schema;
-const { NamedAPIResource } = require('./common');
+const { APIReference } = require('./common');
 
 const Choice = new Schema({
   _id: false,
   choose: Number,
-  from: [NamedAPIResource],
+  from: [APIReference],
   type: String,
 });
 
@@ -21,7 +21,7 @@ const Feature = new Schema({
     select: false,
   },
   choice: Choice,
-  class: NamedAPIResource,
+  class: APIReference,
   desc: [String],
   group: String,
   index: String,
@@ -29,7 +29,7 @@ const Feature = new Schema({
   name: String,
   prerequisites: [Prerequisite],
   reference: String,
-  subclass: NamedAPIResource,
+  subclass: APIReference,
   url: String,
 });
 

--- a/src/models/level.js
+++ b/src/models/level.js
@@ -1,6 +1,6 @@
 const mongoose = require('mongoose');
 const Schema = mongoose.Schema;
-const { NamedAPIResource } = require('./common');
+const { APIReference } = require('./common');
 
 const ClassSpecificCreatingSpellSlot = new Schema({
   _id: false,
@@ -83,15 +83,15 @@ const Level = new Schema({
     select: false,
   },
   ability_score_bonuses: Number,
-  class: NamedAPIResource,
+  class: APIReference,
   class_specific: ClassSpecific,
-  feature_choices: [NamedAPIResource],
-  features: [NamedAPIResource],
+  feature_choices: [APIReference],
+  features: [APIReference],
   index: String,
   level: Number,
   prof_bonus: Number,
   spellcasting: Spellcasting,
-  subclass: NamedAPIResource,
+  subclass: APIReference,
   subclass_specific: SubclassSpecific,
   url: String,
 });

--- a/src/models/magicItem.js
+++ b/src/models/magicItem.js
@@ -1,6 +1,6 @@
 const mongoose = require('mongoose');
 const Schema = mongoose.Schema;
-const { NamedAPIResource } = require('./common');
+const { APIReference } = require('./common');
 
 const MagicItem = new Schema({
   _id: {
@@ -8,7 +8,7 @@ const MagicItem = new Schema({
     select: false,
   },
   desc: [String],
-  equipment_category: NamedAPIResource,
+  equipment_category: APIReference,
   index: String,
   name: String,
   url: String,

--- a/src/models/monster.js
+++ b/src/models/monster.js
@@ -1,11 +1,11 @@
 const mongoose = require('mongoose');
 const Schema = mongoose.Schema;
-const { NamedAPIResource } = require('./common');
+const { APIReference } = require('./common');
 
 const ActionDamage = new Schema({
   _id: false,
   damage_dice: String,
-  damage_type: NamedAPIResource,
+  damage_type: APIReference,
 });
 
 const Action = new Schema({
@@ -36,7 +36,7 @@ const OtherSpeed = new Schema({
 
 const Proficiency = new Schema({
   _id: false,
-  proficiency: NamedAPIResource,
+  proficiency: APIReference,
   value: Number,
 });
 
@@ -81,7 +81,7 @@ const MonsterSchema = new Schema({
   armor_class: Number,
   challenge_rating: Number,
   charisma: Number,
-  condition_immunities: [NamedAPIResource],
+  condition_immunities: [APIReference],
   constitution: Number,
   damage_immunities: [String],
   damage_resistances: [String],

--- a/src/models/proficiency.js
+++ b/src/models/proficiency.js
@@ -1,6 +1,6 @@
 const mongoose = require('mongoose');
 const Schema = mongoose.Schema;
-const { NamedAPIResource } = require('./common');
+const { APIReference } = require('./common');
 
 const Reference = new Schema({
   _id: false,
@@ -15,10 +15,10 @@ const Proficiency = new Schema({
     type: String,
     select: false,
   },
-  classes: [NamedAPIResource],
+  classes: [APIReference],
   index: String,
   name: String,
-  races: [NamedAPIResource],
+  races: [APIReference],
   references: [Reference],
   type: String,
   url: String,

--- a/src/models/race.js
+++ b/src/models/race.js
@@ -1,10 +1,10 @@
 const mongoose = require('mongoose');
 const Schema = mongoose.Schema;
-const { NamedAPIResource } = require('./common');
+const { APIReference } = require('./common');
 
 const AbilityBonusOption = new Schema({
   _id: false,
-  ability_score: NamedAPIResource,
+  ability_score: APIReference,
   bonus: Number,
 });
 
@@ -17,28 +17,28 @@ const RaceAbilityBonusOptions = new Schema({
 
 const RaceAbilityBonus = new Schema({
   _id: false,
-  ability_score: NamedAPIResource,
+  ability_score: APIReference,
   bonus: Number,
 });
 
 const LanguageOptions = new Schema({
   _id: false,
   choose: Number,
-  from: [NamedAPIResource],
+  from: [APIReference],
   type: String,
 });
 
 const StartingProficiencyOptions = new Schema({
   _id: false,
   choose: Number,
-  from: [NamedAPIResource],
+  from: [APIReference],
   type: String,
 });
 
 const TraitOptions = new Schema({
   _id: false,
   choose: Number,
-  from: [NamedAPIResource],
+  from: [APIReference],
   type: String,
 });
 
@@ -54,16 +54,16 @@ const Race = new Schema({
   index: String,
   language_desc: String,
   language_options: LanguageOptions,
-  languages: [NamedAPIResource],
+  languages: [APIReference],
   name: String,
   size: String,
   size_description: String,
   speed: Number,
-  starting_proficiencies: [NamedAPIResource],
+  starting_proficiencies: [APIReference],
   starting_proficiency_options: StartingProficiencyOptions,
-  subraces: [NamedAPIResource],
+  subraces: [APIReference],
   trait_options: TraitOptions,
-  traits: [NamedAPIResource],
+  traits: [APIReference],
   url: String,
 });
 

--- a/src/models/rule.js
+++ b/src/models/rule.js
@@ -1,6 +1,6 @@
 const mongoose = require('mongoose');
 const Schema = mongoose.Schema;
-const { NamedAPIResource } = require('./common');
+const { APIReference } = require('./common');
 
 const Rule = new Schema({
   _id: {
@@ -10,7 +10,7 @@ const Rule = new Schema({
   desc: String,
   index: String,
   name: String,
-  subsections: [NamedAPIResource],
+  subsections: [APIReference],
   url: String,
 });
 

--- a/src/models/skill.js
+++ b/src/models/skill.js
@@ -1,13 +1,13 @@
 const mongoose = require('mongoose');
 const Schema = mongoose.Schema;
-const { NamedAPIResource } = require('./common');
+const { APIReference } = require('./common');
 
 const Skill = new Schema({
   _id: {
     type: String,
     select: false,
   },
-  ability_score: NamedAPIResource,
+  ability_score: APIReference,
   desc: [String],
   index: String,
   name: String,

--- a/src/models/spell.js
+++ b/src/models/spell.js
@@ -1,6 +1,6 @@
 const mongoose = require('mongoose');
 const Schema = mongoose.Schema;
-const { NamedAPIResource } = require('./common');
+const { APIReference } = require('./common');
 
 const AreaOfEffect = new Schema({
   _id: false,
@@ -14,13 +14,13 @@ const Damage = new Schema({
   damage_at_slot_level: Object,
   // As this has keys that are numbers, we have to use an `Object`, which you can't query subfields
   damage_at_character_level: Object,
-  damage_type: NamedAPIResource,
+  damage_type: APIReference,
 });
 
 const DC = new Schema({
   _id: false,
   dc_success: String,
-  dc_type: NamedAPIResource,
+  dc_type: APIReference,
   desc: String,
 });
 
@@ -32,7 +32,7 @@ const Spell = new Schema({
   area_of_effect: AreaOfEffect,
   attack_type: String,
   casting_time: String,
-  classes: [NamedAPIResource],
+  classes: [APIReference],
   components: [String],
   concentration: Boolean,
   damage: Damage,
@@ -48,8 +48,8 @@ const Spell = new Schema({
   name: String,
   range: String,
   ritual: Boolean,
-  school: NamedAPIResource,
-  subclasses: [NamedAPIResource],
+  school: APIReference,
+  subclasses: [APIReference],
   url: String,
 });
 

--- a/src/models/startingEquipment.js
+++ b/src/models/startingEquipment.js
@@ -1,16 +1,16 @@
 const mongoose = require('mongoose');
 const Schema = mongoose.Schema;
-const { NamedAPIResource } = require('./common');
+const { APIReference } = require('./common');
 
 const Equipment = new Schema({
   _id: false,
-  equipment: NamedAPIResource,
+  equipment: APIReference,
   quantity: Number,
 });
 
 const StartingEquipmentOption = new Schema({
   _id: false,
-  equipment: NamedAPIResource,
+  equipment: APIReference,
   quantity: Number,
 });
 
@@ -26,7 +26,7 @@ const StartingEquipment = new Schema({
     type: String,
     select: false,
   },
-  class: NamedAPIResource,
+  class: APIReference,
   index: String,
   starting_equipment: [Equipment],
   starting_equipment_options: [StartingEquipmentOptions],

--- a/src/models/subclass.js
+++ b/src/models/subclass.js
@@ -1,6 +1,6 @@
 const mongoose = require('mongoose');
 const Schema = mongoose.Schema;
-const { NamedAPIResource } = require('./common');
+const { APIReference } = require('./common');
 
 const SpellPrerequisite = new Schema({
   _id: false,
@@ -13,7 +13,7 @@ const SpellPrerequisite = new Schema({
 const Spell = new Schema({
   _id: false,
   prerequisites: [SpellPrerequisite],
-  spell: NamedAPIResource,
+  spell: APIReference,
 });
 
 const Subclass = new Schema({
@@ -21,7 +21,7 @@ const Subclass = new Schema({
     type: String,
     select: false,
   },
-  class: NamedAPIResource,
+  class: APIReference,
   desc: [String],
   index: String,
   name: String,

--- a/src/models/subrace.js
+++ b/src/models/subrace.js
@@ -1,24 +1,24 @@
 const mongoose = require('mongoose');
 const Schema = mongoose.Schema;
-const { NamedAPIResource } = require('./common');
+const { APIReference } = require('./common');
 
 const AbilityBonus = new Schema({
   _id: false,
-  ability_score: NamedAPIResource,
+  ability_score: APIReference,
   bonus: Number,
 });
 
 const LanguageOptions = new Schema({
   _id: false,
   choose: Number,
-  from: [NamedAPIResource],
+  from: [APIReference],
   type: String,
 });
 
 const RacialTraitOptions = new Schema({
   _id: false,
   choose: Number,
-  from: [NamedAPIResource],
+  from: [APIReference],
   type: String,
 });
 
@@ -32,10 +32,10 @@ const Subrace = new Schema({
   index: String,
   language_options: LanguageOptions,
   name: String,
-  race: NamedAPIResource,
+  race: APIReference,
   racial_trait_options: RacialTraitOptions,
-  racial_traits: [NamedAPIResource],
-  starting_proficiencies: [NamedAPIResource],
+  racial_traits: [APIReference],
+  starting_proficiencies: [APIReference],
   url: String,
 });
 

--- a/src/models/trait.js
+++ b/src/models/trait.js
@@ -1,6 +1,6 @@
 const mongoose = require('mongoose');
 const Schema = mongoose.Schema;
-const { NamedAPIResource } = require('./common');
+const { APIReference } = require('./common');
 
 const Proficiency = new Schema({
   _id: false,
@@ -12,7 +12,7 @@ const Proficiency = new Schema({
 const ProficiencyChoices = new Schema({
   _id: false,
   choose: Number,
-  from: [NamedAPIResource],
+  from: [APIReference],
   type: String,
 });
 
@@ -26,8 +26,8 @@ const Trait = new Schema({
   name: String,
   proficiencies: [Proficiency],
   proficiency_choices: ProficiencyChoices,
-  races: [NamedAPIResource],
-  subraces: [NamedAPIResource],
+  races: [APIReference],
+  subraces: [APIReference],
   url: String,
 });
 


### PR DESCRIPTION
## What does this do?
Renames `NamedAPIResource ` to `APIReference`

## How was it tested?
CI

## Is there a Github issue this is resolving?
No

## Here's a fun image for your troubles
![image](https://user-images.githubusercontent.com/353626/101608073-260cb780-39ba-11eb-97c0-0acb1ed97b29.png)
