### PR TITLE
Escape regex in spells

### DIFF
--- a/src/controllers/api/spellController.js
+++ b/src/controllers/api/spellController.js
@@ -14,7 +14,7 @@ exports.index = async (req, res, next) => {
   }
 
   if (req.query.school !== undefined) {
-    const schoolRegex = req.query.school.split(',').map(c => new RegExp(c, 'i'));
+    const schoolRegex = req.query.school.split(',').map(c => new RegExp(escapeRegExp(c), 'i'));
     searchQueries['school.name'] = { $in: schoolRegex };
   }
 


### PR DESCRIPTION
## What does this do?
Fixes a security vulnerability in spells that allowed for regex injection

## How was it tested?
CI

## Is there a Github issue this is resolving?
Security issue

## Here's a fun image for your troubles
![image](https://user-images.githubusercontent.com/353626/102700441-374b9480-4202-11eb-9ffd-b6e8b1c98749.png)
