### PR TITLE
ecs: fix ability scores anchor tag

### DIFF
--- a/src/views/partials/doc-resource-common-models.ejs
+++ b/src/views/partials/doc-resource-common-models.ejs
@@ -129,7 +129,7 @@
       <td align="left">ability_score</td>
       <td align="left">The ability score for this bonus.</td>
       <td align="left">
-        <a href="#apireference">APIReference</a> (<a href="#ability_score">AbilityScore</a>)
+        <a href="#apireference">APIReference</a> (<a href="#ability-scores">AbilityScore</a>)
       </td>
     </tr>
   </tbody>


### PR DESCRIPTION
## What does this do?
- Fix a typo in the anchor tag

## How was it tested?
- localhost

current bad behavior in production:
![asbad](https://user-images.githubusercontent.com/1425775/104947113-13e64780-5970-11eb-89ec-fec30bd225ba.gif)


fixed behavior testing locally:
![as](https://user-images.githubusercontent.com/1425775/104947101-0df06680-5970-11eb-9c75-9a4b09655190.gif)

## Is there a Github issue this is resolving?
- no

## Here's a fun image for your troubles
![random photo - update me](https://picsum.photos/200)
